### PR TITLE
fix(stake): correct DelegateStake account flags

### DIFF
--- a/programs/stake/Deactivate.go
+++ b/programs/stake/Deactivate.go
@@ -92,7 +92,7 @@ func (inst *Deactivate) EncodeToTree(parent treeout.Branches) {
 					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch treeout.Branches) {
 						accountsBranch.Child(format.Meta("            StakeAccount", inst.AccountMetaSlice.Get(0)))
 						accountsBranch.Child(format.Meta("             ClockSysvar", inst.AccountMetaSlice.Get(1)))
-						accountsBranch.Child(format.Meta("           StakeAuthoriy", inst.AccountMetaSlice.Get(2)))
+						accountsBranch.Child(format.Meta("          StakeAuthority", inst.AccountMetaSlice.Get(2)))
 					})
 				})
 		})

--- a/programs/stake/DelegateStake.go
+++ b/programs/stake/DelegateStake.go
@@ -24,7 +24,7 @@ import (
 )
 
 type DelegateStake struct {
-	// [0] = [WRITE SIGNER] StakeAccount
+	// [0] = [WRITE] StakeAccount
 	// ··········· Stake account getting initialized
 	//
 	// [1] = [] Vote Account
@@ -39,7 +39,7 @@ type DelegateStake struct {
 	// [4] = [] Stake Config Account
 	// ··········· The Stake Config Account
 	//
-	// [5] = [WRITE SIGNER] Stake Authoriy
+	// [5] = [SIGNER] Stake Authoriy
 	// ··········· The Stake Authority
 	//
 	solana.AccountMetaSlice `bin:"-" borsh_skip:"true"`
@@ -55,7 +55,7 @@ func (inst *DelegateStake) Validate() error {
 	return nil
 }
 func (inst *DelegateStake) SetStakeAccount(stakeAccount solana.PublicKey) *DelegateStake {
-	inst.AccountMetaSlice[0] = solana.Meta(stakeAccount).WRITE().SIGNER()
+	inst.AccountMetaSlice[0] = solana.Meta(stakeAccount).WRITE()
 	return inst
 }
 func (inst *DelegateStake) SetVoteAccount(voteAcc solana.PublicKey) *DelegateStake {
@@ -75,7 +75,7 @@ func (inst *DelegateStake) SetConfigAccount(stakeConfigAcc solana.PublicKey) *De
 	return inst
 }
 func (inst *DelegateStake) SetStakeAuthority(stakeAuthority solana.PublicKey) *DelegateStake {
-	inst.AccountMetaSlice[5] = solana.Meta(stakeAuthority).WRITE().SIGNER()
+	inst.AccountMetaSlice[5] = solana.Meta(stakeAuthority).SIGNER()
 	return inst
 }
 func (inst *DelegateStake) GetStakeAccount() *solana.AccountMeta { return inst.AccountMetaSlice[0] }

--- a/programs/stake/DelegateStake.go
+++ b/programs/stake/DelegateStake.go
@@ -39,7 +39,7 @@ type DelegateStake struct {
 	// [4] = [] Stake Config Account
 	// ··········· The Stake Config Account
 	//
-	// [5] = [SIGNER] Stake Authoriy
+	// [5] = [SIGNER] Stake Authority
 	// ··········· The Stake Authority
 	//
 	solana.AccountMetaSlice `bin:"-" borsh_skip:"true"`
@@ -112,7 +112,7 @@ func (inst *DelegateStake) EncodeToTree(parent treeout.Branches) {
 						accountsBranch.Child(format.Meta("           ClockSysvar", inst.AccountMetaSlice.Get(2)))
 						accountsBranch.Child(format.Meta("           StakeHistorySysvar", inst.AccountMetaSlice.Get(3)))
 						accountsBranch.Child(format.Meta("           StakeConfigAccount", inst.AccountMetaSlice.Get(4)))
-						accountsBranch.Child(format.Meta("           StakeAuthoriy", inst.AccountMetaSlice.Get(5)))
+						accountsBranch.Child(format.Meta("           StakeAuthority", inst.AccountMetaSlice.Get(5)))
 					})
 				})
 		})

--- a/programs/stake/DelegateStake_test.go
+++ b/programs/stake/DelegateStake_test.go
@@ -25,3 +25,25 @@ func TestRoundTrip_DelegateStake(t *testing.T) {
 	require.NoError(t, err)
 	require.IsType(t, &DelegateStake{}, decoded.Impl)
 }
+
+// The on-chain Stake program's DelegateStake account spec is:
+//
+//  0. [WRITE]  stake account to be delegated
+//  5. [SIGNER] stake authority
+//
+// i.e. the stake account is writable but not a signer, and the stake
+// authority signs but is not writable. This matches the flags the other
+// authority-based stake instructions (Authorize, Deactivate, Split) use.
+func TestAccountFlags_DelegateStake(t *testing.T) {
+	inst := NewDelegateStakeInstructionBuilder().
+		SetStakeAccount(pubkeyOf(1)).
+		SetStakeAuthority(pubkeyOf(4))
+
+	stakeAccount := inst.GetStakeAccount()
+	require.True(t, stakeAccount.IsWritable, "stake account must be writable")
+	require.False(t, stakeAccount.IsSigner, "stake account must not be a signer")
+
+	stakeAuthority := inst.GetStakeAuthority()
+	require.True(t, stakeAuthority.IsSigner, "stake authority must be a signer")
+	require.False(t, stakeAuthority.IsWritable, "stake authority must not be writable")
+}

--- a/programs/stake/Initialize.go
+++ b/programs/stake/Initialize.go
@@ -31,7 +31,7 @@ type Initialize struct {
 	// Lockup settings for stake account
 	Lockup *Lockup
 
-	// [0] = [WRITE SIGNER] StakeAccount
+	// [0] = [WRITE] StakeAccount
 	// ··········· Stake account getting initialized
 	//
 	// [1] = [] RentSysvar
@@ -104,7 +104,7 @@ func (inst *Initialize) Validate() error {
 
 // Stake account account
 func (inst *Initialize) SetStakeAccount(stakeAccount solana.PublicKey) *Initialize {
-	inst.AccountMetaSlice[0] = solana.Meta(stakeAccount).WRITE().SIGNER()
+	inst.AccountMetaSlice[0] = solana.Meta(stakeAccount).WRITE()
 	return inst
 }
 

--- a/programs/stake/Initialize_test.go
+++ b/programs/stake/Initialize_test.go
@@ -37,3 +37,21 @@ func TestRoundTrip_Initialize(t *testing.T) {
 	require.Equal(t, uint64(42), *init.Lockup.Epoch)
 	require.Equal(t, custodian, *init.Lockup.Custodian)
 }
+
+// The on-chain Stake program's Initialize account spec is:
+//
+//  0. [WRITE] uninitialized stake account
+//  1. [] rent sysvar
+//
+// i.e. the stake account is writable but not a signer. Initialize takes the
+// staker/withdrawer authorities as instruction data, not as signing accounts,
+// so nothing in this instruction signs.
+func TestAccountFlags_Initialize(t *testing.T) {
+	inst := NewInitializeInstructionBuilder().
+		SetStakeAccount(pubkeyOf(1)).
+		SetRentSysvarAccount(solana.SysVarRentPubkey)
+
+	stakeAccount := inst.GetStakeAccount()
+	require.True(t, stakeAccount.IsWritable, "stake account must be writable")
+	require.False(t, stakeAccount.IsSigner, "stake account must not be a signer")
+}

--- a/programs/stake/Split.go
+++ b/programs/stake/Split.go
@@ -119,7 +119,7 @@ func (inst *Split) EncodeToTree(parent treeout.Branches) {
 					instructionBranch.Child("Accounts").ParentFunc(func(accountsBranch treeout.Branches) {
 						accountsBranch.Child(format.Meta("              StakeAccount", inst.AccountMetaSlice.Get(0)))
 						accountsBranch.Child(format.Meta("           NewStakeAccount", inst.AccountMetaSlice.Get(1)))
-						accountsBranch.Child(format.Meta("             StakeAuthoriy", inst.AccountMetaSlice.Get(2)))
+						accountsBranch.Child(format.Meta("            StakeAuthority", inst.AccountMetaSlice.Get(2)))
 					})
 				})
 		})

--- a/programs/vote/Withdraw.go
+++ b/programs/vote/Withdraw.go
@@ -35,7 +35,7 @@ type Withdraw struct {
 	// [1] = [WRITE] ToAccount
 	// ··········· Account to receive the funds
 	//
-	// [2] = [WRITE SIGNER] AuthorizedWithdrawerPubkey
+	// [2] = [SIGNER] AuthorizedWithdrawerPubkey
 	// ··········· Account authorized to do the witdraw
 	//
 	solana.AccountMetaSlice `bin:"-" borsh_skip:"true"`
@@ -94,7 +94,7 @@ func (inst *Withdraw) SetRecipientAccount(recipientAccount solana.PublicKey) *Wi
 
 // Withdraw authority account
 func (inst *Withdraw) SetWithdrawAuthorityAccount(withdrawAccount solana.PublicKey) *Withdraw {
-	inst.AccountMetaSlice[2] = solana.Meta(withdrawAccount).WRITE().SIGNER()
+	inst.AccountMetaSlice[2] = solana.Meta(withdrawAccount).SIGNER()
 	return inst
 }
 

--- a/programs/vote/Withdraw_test.go
+++ b/programs/vote/Withdraw_test.go
@@ -20,3 +20,27 @@ func TestRoundTrip_Withdraw(t *testing.T) {
 	w := decoded.Impl.(*Withdraw)
 	require.Equal(t, uint64(1_000_000_000), *w.Lamports)
 }
+
+// The on-chain Vote program's Withdraw account spec is:
+//
+//  0. [WRITE] vote account to withdraw from
+//  1. [WRITE] recipient account
+//  2. [SIGNER] withdraw authority
+//
+// i.e. the withdraw authority is a read-only signer: it authorizes the
+// withdraw but is not itself mutated, so it must not carry the writable flag.
+func TestAccountFlags_Withdraw(t *testing.T) {
+	inst := NewWithdrawInstruction(1, pubkeyOf(1), pubkeyOf(2), pubkeyOf(3))
+
+	vote := inst.GetVoteAccount()
+	require.True(t, vote.IsWritable, "vote account must be writable")
+	require.False(t, vote.IsSigner, "vote account must not be a signer")
+
+	recipient := inst.GetRecipientAccount()
+	require.True(t, recipient.IsWritable, "recipient must be writable")
+	require.False(t, recipient.IsSigner, "recipient must not be a signer")
+
+	withdrawer := inst.GetWithdrawAuthorityAccount()
+	require.False(t, withdrawer.IsWritable, "withdraw authority must be read-only")
+	require.True(t, withdrawer.IsSigner, "withdraw authority must be a signer")
+}


### PR DESCRIPTION
## What

Fixes the account-meta flags on the `DelegateStake` instruction builder in `programs/stake`.

`SetStakeAccount` marked the stake account as `WRITE SIGNER` and `SetStakeAuthority` marked the authority as `WRITE SIGNER`. The on-chain Stake program's `DelegateStake` account spec is:

```
0. [WRITE]  stake account to be delegated
1. []       vote account
2. []       clock sysvar
3. []       stake history sysvar
4. []       stake config account
5. [SIGNER] stake authority
```

So the stake account is writable but does not sign, and the stake authority signs but is not writable. This change drops the extra `SIGNER` from the stake account and the extra `WRITE` from the authority, and updates the struct doc comment to match.

## Why it matters

- Requiring a signature from the stake account forces callers to sign with the stake account key even though the program only needs the stake authority's signature, so a delegation driven purely through the authority could not be assembled with this builder.
- Marking the authority writable inflates the writable set and skews the compiled message header (`numReadonlySignedAccounts`) versus what the program expects.

The other authority-based instructions in the same package (`Authorize`, `Deactivate`, `Split`) already use stake-account `WRITE()` + authority `SIGNER()`; `DelegateStake` was the only one that didn't.

## Test

Added `TestAccountFlags_DelegateStake` asserting the stake account is writable and not a signer, and the authority is a signer and not writable. Existing `TestRoundTrip_DelegateStake` still passes.

## Additional same-class fixes folded in (per review)

- **stake `Initialize`** — `SetStakeAccount` had the identical `WRITE SIGNER` bug; canonical `Initialize` marks the stake account writable non-signer (its keypair signs the preceding `SystemProgram::CreateAccount`, not `Initialize`). Dropped `SIGNER`, fixed the doc comment, added `TestAccountFlags_Initialize`.
- **`Authoriy` -> `Authority`** typo in the tree-print account labels of `Deactivate` / `Split` / `DelegateStake`, with widths realigned.
- **vote `Withdraw`** — `SetWithdrawAuthorityAccount` marked the authorized withdrawer `WRITE SIGNER`; canonical vote `withdraw` marks it `new_readonly(withdrawer, true)` (read-only signer). The authority is not mutated, so the writable flag is spurious — it was the lone outlier vs `Authorize` / `UpdateCommission` / `UpdateValidatorIdentity`. Dropped `WRITE`, fixed the doc comment, added `TestAccountFlags_Withdraw`.

Closes #452
Closes #458
