### PR TITLE
fix(token): mark InitializeMultisig member accounts as read-only

### DIFF
--- a/programs/token-2022/InitializeMultisig.go
+++ b/programs/token-2022/InitializeMultisig.go
@@ -47,7 +47,7 @@ type InitializeMultisig struct {
 	// [1] = [] $(SysVarRentPubkey)
 	// ··········· Rent sysvar.
 	//
-	// [2...] = [SIGNER] signers
+	// [2...] = [] signers
 	// ··········· ..2+N The signer accounts, must equal to N where 1 <= N <=11
 	Accounts ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
 	Signers  ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
@@ -112,7 +112,7 @@ func (inst *InitializeMultisig) GetSysVarRentPubkeyAccount() *ag_solanago.Accoun
 // ..2+N The signer accounts, must equal to N where 1 <= N <=11
 func (inst *InitializeMultisig) AddSigners(signers ...ag_solanago.PublicKey) *InitializeMultisig {
 	for _, signer := range signers {
-		inst.Signers = append(inst.Signers, ag_solanago.Meta(signer).SIGNER())
+		inst.Signers = append(inst.Signers, ag_solanago.Meta(signer))
 	}
 	return inst
 }

--- a/programs/token-2022/InitializeMultisig2.go
+++ b/programs/token-2022/InitializeMultisig2.go
@@ -32,7 +32,7 @@ type InitializeMultisig2 struct {
 	// [0] = [WRITE] account
 	// ··········· The multisignature account to initialize.
 	//
-	// [1] = [SIGNER] signers
+	// [1] = [] signers
 	// ··········· The signer accounts, must equal to N where 1 <= N <= 11.
 	Accounts ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
 	Signers  ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
@@ -82,7 +82,7 @@ func (inst *InitializeMultisig2) GetAccount() *ag_solanago.AccountMeta {
 // The signer accounts, must equal to N where 1 <= N <= 11.
 func (inst *InitializeMultisig2) AddSigners(signers ...ag_solanago.PublicKey) *InitializeMultisig2 {
 	for _, signer := range signers {
-		inst.Signers = append(inst.Signers, ag_solanago.Meta(signer).SIGNER())
+		inst.Signers = append(inst.Signers, ag_solanago.Meta(signer))
 	}
 	return inst
 }

--- a/programs/token-2022/InitializeMultisig_flags_test.go
+++ b/programs/token-2022/InitializeMultisig_flags_test.go
@@ -1,0 +1,63 @@
+package token2022
+
+import (
+	"testing"
+
+	ag_solanago "github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/require"
+)
+
+// The on-chain SPL Token-2022 InitializeMultisig / InitializeMultisig2 account
+// spec marks the signer (member) accounts as read-only, non-signer:
+//
+//	InitializeMultisig
+//	  0.   [WRITE] the multisignature account to initialize
+//	  1.   []      rent sysvar
+//	  2+N. []      the signer (member) accounts
+//
+//	InitializeMultisig2
+//	  0.   [WRITE] the multisignature account to initialize
+//	  1+N. []      the signer (member) accounts
+//
+// The member pubkeys are only recorded into the multisig account data; the
+// instruction itself requires no signers, so the members must NOT carry the
+// signer flag. Marking them as signers would force every prospective member to
+// sign the setup transaction, which the program does not require.
+func TestAccountFlags_InitializeMultisig(t *testing.T) {
+	inst := NewInitializeMultisigInstructionBuilder().
+		SetM(2).
+		SetAccount(ag_solanago.PublicKey{1}).
+		SetSysVarRentPubkeyAccount(ag_solanago.SysVarRentPubkey).
+		AddSigners(ag_solanago.PublicKey{2}, ag_solanago.PublicKey{3})
+
+	account := inst.GetAccount()
+	require.True(t, account.IsWritable, "multisig account must be writable")
+	require.False(t, account.IsSigner, "multisig account must not be a signer")
+
+	rent := inst.GetSysVarRentPubkeyAccount()
+	require.False(t, rent.IsWritable, "rent sysvar must not be writable")
+	require.False(t, rent.IsSigner, "rent sysvar must not be a signer")
+
+	require.Len(t, inst.Signers, 2)
+	for i, s := range inst.Signers {
+		require.False(t, s.IsSigner, "member account %d must not be a signer", i)
+		require.False(t, s.IsWritable, "member account %d must not be writable", i)
+	}
+}
+
+func TestAccountFlags_InitializeMultisig2(t *testing.T) {
+	inst := NewInitializeMultisig2InstructionBuilder().
+		SetM(2).
+		SetAccount(ag_solanago.PublicKey{1}).
+		AddSigners(ag_solanago.PublicKey{2}, ag_solanago.PublicKey{3})
+
+	account := inst.GetAccount()
+	require.True(t, account.IsWritable, "multisig account must be writable")
+	require.False(t, account.IsSigner, "multisig account must not be a signer")
+
+	require.Len(t, inst.Signers, 2)
+	for i, s := range inst.Signers {
+		require.False(t, s.IsSigner, "member account %d must not be a signer", i)
+		require.False(t, s.IsWritable, "member account %d must not be writable", i)
+	}
+}

--- a/programs/token/InitializeMultisig.go
+++ b/programs/token/InitializeMultisig.go
@@ -47,7 +47,7 @@ type InitializeMultisig struct {
 	// [1] = [] $(SysVarRentPubkey)
 	// ··········· Rent sysvar.
 	//
-	// [2...] = [SIGNER] signers
+	// [2...] = [] signers
 	// ··········· ..2+N The signer accounts, must equal to N where 1 <= N <=11
 	Accounts ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
 	Signers  ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
@@ -112,7 +112,7 @@ func (inst *InitializeMultisig) GetSysVarRentPubkeyAccount() *ag_solanago.Accoun
 // ..2+N The signer accounts, must equal to N where 1 <= N <=11
 func (inst *InitializeMultisig) AddSigners(signers ...ag_solanago.PublicKey) *InitializeMultisig {
 	for _, signer := range signers {
-		inst.Signers = append(inst.Signers, ag_solanago.Meta(signer).SIGNER())
+		inst.Signers = append(inst.Signers, ag_solanago.Meta(signer))
 	}
 	return inst
 }

--- a/programs/token/InitializeMultisig2.go
+++ b/programs/token/InitializeMultisig2.go
@@ -32,7 +32,7 @@ type InitializeMultisig2 struct {
 	// [0] = [WRITE] account
 	// ··········· The multisignature account to initialize.
 	//
-	// [1] = [SIGNER] signers
+	// [1] = [] signers
 	// ··········· The signer accounts, must equal to N where 1 <= N <= 11.
 	Accounts ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
 	Signers  ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
@@ -82,7 +82,7 @@ func (inst *InitializeMultisig2) GetAccount() *ag_solanago.AccountMeta {
 // The signer accounts, must equal to N where 1 <= N <= 11.
 func (inst *InitializeMultisig2) AddSigners(signers ...ag_solanago.PublicKey) *InitializeMultisig2 {
 	for _, signer := range signers {
-		inst.Signers = append(inst.Signers, ag_solanago.Meta(signer).SIGNER())
+		inst.Signers = append(inst.Signers, ag_solanago.Meta(signer))
 	}
 	return inst
 }

--- a/programs/token/InitializeMultisig_flags_test.go
+++ b/programs/token/InitializeMultisig_flags_test.go
@@ -1,0 +1,63 @@
+package token
+
+import (
+	"testing"
+
+	ag_solanago "github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/require"
+)
+
+// The on-chain SPL Token InitializeMultisig / InitializeMultisig2 account spec
+// marks the signer (member) accounts as read-only, non-signer:
+//
+//	InitializeMultisig
+//	  0.   [WRITE] the multisignature account to initialize
+//	  1.   []      rent sysvar
+//	  2+N. []      the signer (member) accounts
+//
+//	InitializeMultisig2
+//	  0.   [WRITE] the multisignature account to initialize
+//	  1+N. []      the signer (member) accounts
+//
+// The member pubkeys are only recorded into the multisig account data; the
+// instruction itself requires no signers, so the members must NOT carry the
+// signer flag. Marking them as signers would force every prospective member to
+// sign the setup transaction, which the program does not require.
+func TestAccountFlags_InitializeMultisig(t *testing.T) {
+	inst := NewInitializeMultisigInstructionBuilder().
+		SetM(2).
+		SetAccount(ag_solanago.PublicKey{1}).
+		SetSysVarRentPubkeyAccount(ag_solanago.SysVarRentPubkey).
+		AddSigners(ag_solanago.PublicKey{2}, ag_solanago.PublicKey{3})
+
+	account := inst.GetAccount()
+	require.True(t, account.IsWritable, "multisig account must be writable")
+	require.False(t, account.IsSigner, "multisig account must not be a signer")
+
+	rent := inst.GetSysVarRentPubkeyAccount()
+	require.False(t, rent.IsWritable, "rent sysvar must not be writable")
+	require.False(t, rent.IsSigner, "rent sysvar must not be a signer")
+
+	require.Len(t, inst.Signers, 2)
+	for i, s := range inst.Signers {
+		require.False(t, s.IsSigner, "member account %d must not be a signer", i)
+		require.False(t, s.IsWritable, "member account %d must not be writable", i)
+	}
+}
+
+func TestAccountFlags_InitializeMultisig2(t *testing.T) {
+	inst := NewInitializeMultisig2InstructionBuilder().
+		SetM(2).
+		SetAccount(ag_solanago.PublicKey{1}).
+		AddSigners(ag_solanago.PublicKey{2}, ag_solanago.PublicKey{3})
+
+	account := inst.GetAccount()
+	require.True(t, account.IsWritable, "multisig account must be writable")
+	require.False(t, account.IsSigner, "multisig account must not be a signer")
+
+	require.Len(t, inst.Signers, 2)
+	for i, s := range inst.Signers {
+		require.False(t, s.IsSigner, "member account %d must not be a signer", i)
+		require.False(t, s.IsWritable, "member account %d must not be writable", i)
+	}
+}


### PR DESCRIPTION
## What

`InitializeMultisig` and `InitializeMultisig2`, in both `programs/token` and `programs/token-2022`, tagged each multisig **member account** with the signer flag:

```go
inst.Signers = append(inst.Signers, ag_solanago.Meta(signer).SIGNER())
```

The canonical SPL Token account spec declares those accounts read-only, non-signer:

```
InitializeMultisig
  0.      [writable] The multisignature account to initialize.
  1.      []         Rent sysvar.
  2..2+N. []         The signer accounts, must equal to N where 1 <= N <= 11.

InitializeMultisig2
  0.      [writable] The multisignature account to initialize.
  1..1+N. []         The signer accounts.
```

The program only records the member pubkeys into the multisig account data; it does not require them to sign the `InitializeMultisig` transaction. The struct's own doc comment already states this (`"The InitializeMultisig instruction requires no signers ..."`), so the builder contradicted its own documentation.

## Fix

Drop the spurious `.SIGNER()` in `AddSigners` for both instructions in both programs, and sync the `[2...] = [SIGNER]` / `[1] = [SIGNER]` annotation headers to `[]`. One-flag change per builder; the multisig account itself stays `[WRITE]`, the rent sysvar stays read-only.

## Tests

Adds `TestAccountFlags_InitializeMultisig` / `TestAccountFlags_InitializeMultisig2` to both packages, asserting the members are read-only non-signer and the multisig account is writable. Proven to fail on the current code (`member account 0 must not be a signer`) and pass with the fix. `go build ./...`, `go vet`, and the full `programs/token` + `programs/token-2022` suites are green; gofmt clean.

Closes #460.

Same account-flag correctness class as #452 / #458 (folded into #453). Kept as a separate PR since it is a different program and does not overlap those diffs, but happy to fold it into #453 instead if you prefer a single account-flags PR.
