### PR TITLE
feat: account state

### DIFF
--- a/account.go
+++ b/account.go
@@ -202,6 +202,17 @@ func calcSplitAtLengths(total int, index int) (int, int) {
 // The bincode codec below matches the Rust serde encoding of
 // solana_account::Account exactly (fields in declaration order,
 // little-endian integers, Vec<u8> as u64 length + bytes).
+//
+// The json tags are a plain debug/convenience form only; the resulting JSON
+// is not compatible with the JSON-RPC shape of rpc.Account (in particular,
+// Data encodes as base64 rather than the RPC data envelope).
+//
+// NOTE: MarshalWithEncoder/UnmarshalWithDecoder are custom-codec hooks that
+// every gagliardetto/binary encoder dispatches to, so a borsh or compact-u16
+// container with an Account field still emits the bincode layout for it.
+// Likewise, embedding Account anonymously in another struct promotes these
+// methods to the outer type, which would then (de)serialize only the Account
+// fields; give such wrapper structs their own codec methods.
 type Account struct {
 	// Lamports in the account.
 	Lamports uint64 `json:"lamports"`
@@ -249,22 +260,30 @@ func (a *Account) UnmarshalWithDecoder(decoder *bin.Decoder) error {
 	if err != nil {
 		return err
 	}
+	// Check against Remaining() before converting to int: on 32-bit
+	// platforms int(dataLen) would truncate, which ReadNBytes could not
+	// detect. It also yields a clear error for malformed input.
 	if dataLen > uint64(decoder.Remaining()) {
 		return fmt.Errorf("account data length %d exceeds remaining buffer %d", dataLen, decoder.Remaining())
 	}
-	data, err := decoder.ReadNBytes(int(dataLen))
-	if err != nil {
-		return err
+	if dataLen == 0 {
+		// Canonical nil for empty data keeps decode(encode(x)) exact.
+		a.Data = nil
+	} else {
+		data, err := decoder.ReadNBytes(int(dataLen))
+		if err != nil {
+			return err
+		}
+		// ReadNBytes returns a view into the decoder's buffer; clone so the
+		// account neither observes later mutations of the caller's input nor
+		// can corrupt it through append.
+		a.Data = bytes.Clone(data)
 	}
-	// ReadNBytes returns a view into the decoder's buffer; clone so the
-	// account neither observes later mutations of the caller's input nor
-	// can corrupt it through append.
-	a.Data = bytes.Clone(data)
 	owner, err := decoder.ReadNBytes(32)
 	if err != nil {
 		return err
 	}
-	copy(a.Owner[:], owner)
+	a.Owner = PublicKeyFromBytes(owner)
 	// Read the bool byte strictly: Rust bincode rejects values other than
 	// 0 and 1, while decoder.ReadBool accepts any non-zero byte as true.
 	execByte, err := decoder.ReadByte()
@@ -282,19 +301,26 @@ func (a *Account) UnmarshalWithDecoder(decoder *bin.Decoder) error {
 // MarshalBinary bincode-encodes the account, matching the Rust serde
 // encoding of solana_account::Account.
 func (a Account) MarshalBinary() ([]byte, error) {
-	buf := new(bytes.Buffer)
+	// The output size is known exactly, so a pre-sized buffer makes the
+	// encode a single allocation instead of geometric growth.
+	buf := bytes.NewBuffer(make([]byte, 0, 8+8+len(a.Data)+32+1+8))
 	if err := a.MarshalWithEncoder(bin.NewBinEncoder(buf)); err != nil {
 		return nil, err
 	}
 	return buf.Bytes(), nil
 }
 
-// UnmarshalBinary decodes a bincode-encoded account.
+// UnmarshalBinary decodes a bincode-encoded account. Trailing bytes after
+// the account are tolerated: Rust's bincode::deserialize free function is
+// declared with allow_trailing_bytes(), and Agave decodes account state
+// through it (e.g. Account::deserialize_data), so leniency IS the parity
+// behavior.
 func (a *Account) UnmarshalBinary(data []byte) error {
 	return a.UnmarshalWithDecoder(bin.NewBinDecoder(data))
 }
 
-// DecodeAccount decodes a bincode-encoded solana_account::Account.
+// DecodeAccount decodes a bincode-encoded solana_account::Account. Trailing
+// bytes are tolerated; see UnmarshalBinary.
 func DecodeAccount(data []byte) (*Account, error) {
 	var a Account
 	if err := a.UnmarshalBinary(data); err != nil {

--- a/account.go
+++ b/account.go
@@ -19,7 +19,10 @@ package solana
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
+
+	bin "github.com/gagliardetto/binary"
 )
 
 // Wallet is a wrapper around a PrivateKey
@@ -185,4 +188,117 @@ func calcSplitAtLengths(total int, index int) (int, int) {
 		return total, 0
 	}
 	return index, total - index
+}
+
+// Account is the on-chain state of an account: lamports, raw data, owner,
+// executable flag, and rent epoch.
+//
+// This is a port of the upstream anza-xyz/solana-sdk `account` crate's
+// `Account` struct. It is the plain binary-state counterpart of rpc.Account
+// (which is shaped for JSON-RPC responses): use this type when working with
+// bincode-encoded account state, test fixtures, or off-chain tooling that
+// mirrors validator-side types.
+//
+// The bincode codec below matches the Rust serde encoding of
+// solana_account::Account exactly (fields in declaration order,
+// little-endian integers, Vec<u8> as u64 length + bytes).
+type Account struct {
+	// Lamports in the account.
+	Lamports uint64 `json:"lamports"`
+
+	// Data held in this account.
+	Data []byte `json:"data"`
+
+	// Owner is the program that owns this account. If executable, the
+	// program that loads this account.
+	Owner PublicKey `json:"owner"`
+
+	// Executable indicates whether this account's data contains a loaded
+	// program (and is now read-only).
+	Executable bool `json:"executable"`
+
+	// RentEpoch is the epoch at which this account will next owe rent.
+	RentEpoch uint64 `json:"rentEpoch"`
+}
+
+func (a Account) MarshalWithEncoder(encoder *bin.Encoder) error {
+	if err := encoder.WriteUint64(a.Lamports, binary.LittleEndian); err != nil {
+		return err
+	}
+	if err := encoder.WriteUint64(uint64(len(a.Data)), binary.LittleEndian); err != nil {
+		return err
+	}
+	if err := encoder.WriteBytes(a.Data, false); err != nil {
+		return err
+	}
+	if err := encoder.WriteBytes(a.Owner[:], false); err != nil {
+		return err
+	}
+	if err := encoder.WriteBool(a.Executable); err != nil {
+		return err
+	}
+	return encoder.WriteUint64(a.RentEpoch, binary.LittleEndian)
+}
+
+func (a *Account) UnmarshalWithDecoder(decoder *bin.Decoder) error {
+	var err error
+	if a.Lamports, err = decoder.ReadUint64(binary.LittleEndian); err != nil {
+		return err
+	}
+	dataLen, err := decoder.ReadUint64(binary.LittleEndian)
+	if err != nil {
+		return err
+	}
+	if dataLen > uint64(decoder.Remaining()) {
+		return fmt.Errorf("account data length %d exceeds remaining buffer %d", dataLen, decoder.Remaining())
+	}
+	data, err := decoder.ReadNBytes(int(dataLen))
+	if err != nil {
+		return err
+	}
+	// ReadNBytes returns a view into the decoder's buffer; clone so the
+	// account neither observes later mutations of the caller's input nor
+	// can corrupt it through append.
+	a.Data = bytes.Clone(data)
+	owner, err := decoder.ReadNBytes(32)
+	if err != nil {
+		return err
+	}
+	copy(a.Owner[:], owner)
+	// Read the bool byte strictly: Rust bincode rejects values other than
+	// 0 and 1, while decoder.ReadBool accepts any non-zero byte as true.
+	execByte, err := decoder.ReadByte()
+	if err != nil {
+		return err
+	}
+	if execByte > 1 {
+		return fmt.Errorf("invalid bool byte %d for executable flag", execByte)
+	}
+	a.Executable = execByte == 1
+	a.RentEpoch, err = decoder.ReadUint64(binary.LittleEndian)
+	return err
+}
+
+// MarshalBinary bincode-encodes the account, matching the Rust serde
+// encoding of solana_account::Account.
+func (a Account) MarshalBinary() ([]byte, error) {
+	buf := new(bytes.Buffer)
+	if err := a.MarshalWithEncoder(bin.NewBinEncoder(buf)); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// UnmarshalBinary decodes a bincode-encoded account.
+func (a *Account) UnmarshalBinary(data []byte) error {
+	return a.UnmarshalWithDecoder(bin.NewBinDecoder(data))
+}
+
+// DecodeAccount decodes a bincode-encoded solana_account::Account.
+func DecodeAccount(data []byte) (*Account, error) {
+	var a Account
+	if err := a.UnmarshalBinary(data); err != nil {
+		return nil, fmt.Errorf("failed to decode account: %w", err)
+	}
+	return &a, nil
 }

--- a/account_test.go
+++ b/account_test.go
@@ -18,6 +18,7 @@
 package solana
 
 import (
+	"encoding/binary"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -216,4 +217,158 @@ func TestSplitFrom(t *testing.T) {
 		func() {
 			slice.SplitFrom(-1)
 		})
+}
+
+// rustAccountFixture builds the expected bincode encoding by hand:
+// lamports u64 LE, data u64 LE length + bytes, owner 32 raw bytes,
+// executable u8, rent_epoch u64 LE. This pins the wire format against the
+// Rust serde encoding of solana_account::Account independent of the codec
+// implementation.
+func rustAccountFixture(a Account) []byte {
+	out := make([]byte, 0, 8+8+len(a.Data)+32+1+8)
+	out = binary.LittleEndian.AppendUint64(out, a.Lamports)
+	out = binary.LittleEndian.AppendUint64(out, uint64(len(a.Data)))
+	out = append(out, a.Data...)
+	out = append(out, a.Owner[:]...)
+	if a.Executable {
+		out = append(out, 1)
+	} else {
+		out = append(out, 0)
+	}
+	out = binary.LittleEndian.AppendUint64(out, a.RentEpoch)
+	return out
+}
+
+func TestAccountBincodeRoundTrip(t *testing.T) {
+	owner := MustPublicKeyFromBase58("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA")
+	cases := []struct {
+		name string
+		acct Account
+	}{
+		{
+			name: "typical",
+			acct: Account{
+				Lamports:   1_461_600,
+				Data:       []byte{1, 2, 3, 4, 5},
+				Owner:      owner,
+				Executable: false,
+				RentEpoch:  361,
+			},
+		},
+		{
+			name: "empty data",
+			acct: Account{
+				Lamports:  1,
+				Owner:     SystemProgramID,
+				RentEpoch: ^uint64(0),
+			},
+		},
+		{
+			name: "executable",
+			acct: Account{
+				Lamports:   928_408_320,
+				Data:       make([]byte, 36),
+				Owner:      MustPublicKeyFromBase58("BPFLoaderUpgradeab1e11111111111111111111111"),
+				Executable: true,
+			},
+		},
+		{
+			name: "zero value",
+			acct: Account{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			enc, err := tc.acct.MarshalBinary()
+			require.NoError(t, err)
+			assert.Equal(t, rustAccountFixture(tc.acct), enc, "encoding must match Rust bincode layout")
+
+			dec, err := DecodeAccount(enc)
+			require.NoError(t, err)
+			// The decoder may yield empty-but-non-nil data where the input
+			// had nil; assert emptiness, then normalize for the deep equal.
+			if len(tc.acct.Data) == 0 {
+				require.Empty(t, dec.Data)
+				dec.Data = tc.acct.Data
+			}
+			assert.Equal(t, tc.acct, *dec)
+		})
+	}
+}
+
+func TestDecodeAccountErrors(t *testing.T) {
+	// Truncated header.
+	_, err := DecodeAccount([]byte{1, 2, 3})
+	require.Error(t, err)
+
+	// Declared data length exceeds the buffer: must error, not over-allocate.
+	bad := make([]byte, 16)
+	binary.LittleEndian.PutUint64(bad[8:16], 1<<40)
+	_, err = DecodeAccount(bad)
+	require.Error(t, err)
+
+	// Truncated after data (missing owner/flags/rent epoch).
+	acct := Account{Lamports: 5, Data: []byte{9, 9}, RentEpoch: 7}
+	enc, err := acct.MarshalBinary()
+	require.NoError(t, err)
+	_, err = DecodeAccount(enc[:len(enc)-9])
+	require.Error(t, err)
+
+	// Executable byte other than 0/1 must be rejected, matching Rust
+	// bincode's strict bool decoding.
+	enc[len(enc)-9] = 2
+	_, err = DecodeAccount(enc)
+	require.Error(t, err)
+}
+
+func TestDecodeAccountDoesNotAliasInput(t *testing.T) {
+	// Owner must be non-zero: clear(enc) zeroes the buffer, so an all-zero
+	// owner (e.g. SystemProgramID) would make the owner assertion pass even
+	// against an aliased buffer.
+	owner := MustPublicKeyFromBase58("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA")
+	acct := Account{
+		Lamports:  42,
+		Data:      []byte{1, 2, 3},
+		Owner:     owner,
+		RentEpoch: 9,
+	}
+	enc, err := acct.MarshalBinary()
+	require.NoError(t, err)
+
+	dec, err := DecodeAccount(enc)
+	require.NoError(t, err)
+
+	// Mutating the input buffer after decoding must not change the account.
+	clear(enc)
+	assert.Equal(t, []byte{1, 2, 3}, dec.Data)
+	assert.Equal(t, owner, dec.Owner)
+}
+
+func FuzzDecodeAccount(f *testing.F) {
+	seedAcct := Account{
+		Lamports:  1_461_600,
+		Data:      []byte{1, 2, 3, 4, 5},
+		Owner:     SystemProgramID,
+		RentEpoch: 361,
+	}
+	seed, err := seedAcct.MarshalBinary()
+	if err != nil {
+		f.Fatal(err)
+	}
+	f.Add(seed)
+	f.Add([]byte{})
+	f.Add(make([]byte, 57))
+	f.Fuzz(func(t *testing.T, data []byte) {
+		dec, err := DecodeAccount(data)
+		if err != nil {
+			return
+		}
+		// Anything that decodes must re-encode to the exact bytes consumed.
+		// Trailing input bytes are tolerated (bincode parity), so compare
+		// against the matching prefix.
+		enc, err := dec.MarshalBinary()
+		require.NoError(t, err)
+		require.LessOrEqual(t, len(enc), len(data))
+		require.Equal(t, enc, data[:len(enc)])
+	})
 }

--- a/account_test.go
+++ b/account_test.go
@@ -18,9 +18,11 @@
 package solana
 
 import (
+	"bytes"
 	"encoding/binary"
 	"testing"
 
+	bin "github.com/gagliardetto/binary"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -285,12 +287,6 @@ func TestAccountBincodeRoundTrip(t *testing.T) {
 
 			dec, err := DecodeAccount(enc)
 			require.NoError(t, err)
-			// The decoder may yield empty-but-non-nil data where the input
-			// had nil; assert emptiness, then normalize for the deep equal.
-			if len(tc.acct.Data) == 0 {
-				require.Empty(t, dec.Data)
-				dec.Data = tc.acct.Data
-			}
 			assert.Equal(t, tc.acct, *dec)
 		})
 	}
@@ -301,7 +297,9 @@ func TestDecodeAccountErrors(t *testing.T) {
 	_, err := DecodeAccount([]byte{1, 2, 3})
 	require.Error(t, err)
 
-	// Declared data length exceeds the buffer: must error, not over-allocate.
+	// Declared data length exceeds the buffer: must error. The explicit
+	// bounds check also keeps int(dataLen) from truncating on 32-bit
+	// platforms, where ReadNBytes alone could not catch it.
 	bad := make([]byte, 16)
 	binary.LittleEndian.PutUint64(bad[8:16], 1<<40)
 	_, err = DecodeAccount(bad)
@@ -319,6 +317,56 @@ func TestDecodeAccountErrors(t *testing.T) {
 	enc[len(enc)-9] = 2
 	_, err = DecodeAccount(enc)
 	require.Error(t, err)
+}
+
+func TestDecodeAccountToleratesTrailingBytes(t *testing.T) {
+	// Rust's bincode::deserialize free function is declared with
+	// allow_trailing_bytes(), and Agave decodes account state through it,
+	// so extra bytes after the account (e.g. padding in a fixed-size
+	// record) must not fail the decode.
+	acct := Account{
+		Lamports:  42,
+		Data:      []byte{1, 2, 3},
+		Owner:     MustPublicKeyFromBase58("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"),
+		RentEpoch: 9,
+	}
+	enc, err := acct.MarshalBinary()
+	require.NoError(t, err)
+
+	dec, err := DecodeAccount(append(enc, make([]byte, 7)...))
+	require.NoError(t, err)
+	assert.Equal(t, acct, *dec)
+}
+
+func TestAccountStreamRoundTrip(t *testing.T) {
+	// Accounts encoded back to back must decode sequentially from a single
+	// buffer via the streaming codec, mirroring Rust deserialize_from on a
+	// reader carrying multiple values.
+	accts := []Account{
+		{
+			Lamports:  1,
+			Data:      []byte{0xAA, 0xBB},
+			Owner:     MustPublicKeyFromBase58("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"),
+			RentEpoch: 2,
+		},
+		{
+			Lamports:   3,
+			Owner:      MustPublicKeyFromBase58("BPFLoaderUpgradeab1e11111111111111111111111"),
+			Executable: true,
+		},
+	}
+	buf := new(bytes.Buffer)
+	enc := bin.NewBinEncoder(buf)
+	for _, a := range accts {
+		require.NoError(t, a.MarshalWithEncoder(enc))
+	}
+	dec := bin.NewBinDecoder(buf.Bytes())
+	for _, want := range accts {
+		var got Account
+		require.NoError(t, got.UnmarshalWithDecoder(dec))
+		assert.Equal(t, want, got)
+	}
+	require.Zero(t, dec.Remaining())
 }
 
 func TestDecodeAccountDoesNotAliasInput(t *testing.T) {
@@ -364,8 +412,9 @@ func FuzzDecodeAccount(f *testing.F) {
 			return
 		}
 		// Anything that decodes must re-encode to the exact bytes consumed.
-		// Trailing input bytes are tolerated (bincode parity), so compare
-		// against the matching prefix.
+		// Trailing input bytes are tolerated, matching Rust's
+		// bincode::deserialize free function (declared with
+		// allow_trailing_bytes), so compare against the matching prefix.
 		enc, err := dec.MarshalBinary()
 		require.NoError(t, err)
 		require.LessOrEqual(t, len(enc), len(data))

--- a/message.go
+++ b/message.go
@@ -1058,3 +1058,36 @@ type MessageHeader struct {
 	// The last `numReadonlyUnsignedAccounts` of the unsigned keys are read-only accounts.
 	NumReadonlyUnsignedAccounts uint8 `json:"numReadonlyUnsignedAccounts"`
 }
+
+// InnerInstruction is one cross-program invocation (CPI) recorded while a
+// transaction executed, together with the depth at which it ran.
+//
+// This is a port of the upstream anza-xyz/solana-sdk
+// `message::inner_instruction::InnerInstruction` struct. It complements
+// rpc.InnerInstruction (which is shaped for JSON-RPC responses) as the plain
+// core-SDK representation, reusing this package's CompiledInstruction.
+//
+// NOTE: this is a data-model port only; it is NOT bincode-layout-compatible
+// with the Rust struct. Reflection-based bin encoding would write StackHeight
+// as a little-endian u16 (Rust serializes a u8) and CompiledInstruction's
+// widened uint16 indices instead of u8 indices with short-vec lengths.
+type InnerInstruction struct {
+	// Instruction is the compiled instruction that was invoked. Its account
+	// and program indices point into the enclosing transaction message's
+	// account-keys table.
+	Instruction CompiledInstruction `json:"instruction"`
+
+	// StackHeight is the invocation stack height of this instruction: the
+	// runtime's TRANSACTION_LEVEL_STACK_HEIGHT (1) is a top-level
+	// instruction, 2 and deeper are CPIs.
+	// NOTE: it is actually a uint8, but using a uint16 for consistency with
+	// how this package widens u8 message indices.
+	StackHeight uint16 `json:"stackHeight"`
+}
+
+// InnerInstructionsList groups the recorded CPIs of one transaction: the
+// outer slice is indexed by top-level instruction index, each inner slice
+// holds the CPIs that instruction triggered, in execution order.
+//
+// Port of solana-sdk `message::inner_instruction::InnerInstructionsList`.
+type InnerInstructionsList [][]InnerInstruction

--- a/message.go
+++ b/message.go
@@ -1058,36 +1058,3 @@ type MessageHeader struct {
 	// The last `numReadonlyUnsignedAccounts` of the unsigned keys are read-only accounts.
 	NumReadonlyUnsignedAccounts uint8 `json:"numReadonlyUnsignedAccounts"`
 }
-
-// InnerInstruction is one cross-program invocation (CPI) recorded while a
-// transaction executed, together with the depth at which it ran.
-//
-// This is a port of the upstream anza-xyz/solana-sdk
-// `message::inner_instruction::InnerInstruction` struct. It complements
-// rpc.InnerInstruction (which is shaped for JSON-RPC responses) as the plain
-// core-SDK representation, reusing this package's CompiledInstruction.
-//
-// NOTE: this is a data-model port only; it is NOT bincode-layout-compatible
-// with the Rust struct. Reflection-based bin encoding would write StackHeight
-// as a little-endian u16 (Rust serializes a u8) and CompiledInstruction's
-// widened uint16 indices instead of u8 indices with short-vec lengths.
-type InnerInstruction struct {
-	// Instruction is the compiled instruction that was invoked. Its account
-	// and program indices point into the enclosing transaction message's
-	// account-keys table.
-	Instruction CompiledInstruction `json:"instruction"`
-
-	// StackHeight is the invocation stack height of this instruction: the
-	// runtime's TRANSACTION_LEVEL_STACK_HEIGHT (1) is a top-level
-	// instruction, 2 and deeper are CPIs.
-	// NOTE: it is actually a uint8, but using a uint16 for consistency with
-	// how this package widens u8 message indices.
-	StackHeight uint16 `json:"stackHeight"`
-}
-
-// InnerInstructionsList groups the recorded CPIs of one transaction: the
-// outer slice is indexed by top-level instruction index, each inner slice
-// holds the CPIs that instruction triggered, in execution order.
-//
-// Port of solana-sdk `message::inner_instruction::InnerInstructionsList`.
-type InnerInstructionsList [][]InnerInstruction


### PR DESCRIPTION
### Problem

SDK had no counterpart to the Rust solana-sdk core account-state types: there was no way to work with bincode-encoded `solana_account::Account` data (test fixtures, snapshots, validator-side tooling) or to represent recorded CPIs outside the JSON-RPC-shaped types

### Summary of Changes

- added `solana.Account`  as the plain binary-state counterpart of `rpc.Account`, ported from the upstream account crate.
Implemented a bincode codec for it matching the Rust serde
- hardened the decode path: length prefix validated against the remaining buffer before allocation, decoded data cloned so it never aliases the caller's input, and executable bytes other than 0/1 rejected for Rust bincode parity.
- added `InnerInstruction` and `InnerInstructionsList` types to `message.go`