### PR TITLE
fix(ws): send jsonParsed encoding in ParsedBlockSubscribe with nil options

### DIFF
--- a/rpc/ws/blockSubscribe_test.go
+++ b/rpc/ws/blockSubscribe_test.go
@@ -51,3 +51,24 @@ func TestBlockSubscribeRejectsUnsupportedEncoding(t *testing.T) {
 		t.Fatalf("error should describe an unsupported encoding, got: %v", err)
 	}
 }
+
+// TestParsedBlockSubscribeSendsJSONParsedWithNilOpts pins that the jsonParsed
+// encoding is sent even when no options are supplied. Without it the server
+// falls back to its base64 default, which the parsed result type cannot decode.
+func TestParsedBlockSubscribeSendsJSONParsedWithNilOpts(t *testing.T) {
+	m := newMockWSServer(t)
+	defer m.stop()
+	c := connectClient(t, m)
+	defer c.Close()
+
+	ch := make(chan error, 1)
+	go func() {
+		_, err := c.ParsedBlockSubscribe(NewBlockSubscribeFilterAll(), nil)
+		ch <- err
+	}()
+
+	params := readSubscribeParams(t, m, 1)
+	require.NoError(t, <-ch)
+
+	require.Equal(t, string(solana.EncodingJSONParsed), params["encoding"])
+}

--- a/rpc/ws/parsedBlockSubscribe.go
+++ b/rpc/ws/parsedBlockSubscribe.go
@@ -52,12 +52,15 @@ func (cl *Client) ParsedBlockSubscribe(
 			params = append(params, rpc.M{"mentionsAccountOrProgram": v.Pubkey})
 		}
 	}
+	// The jsonParsed encoding is what distinguishes this subscription from
+	// BlockSubscribe, so it must be sent regardless of the caller's options.
+	obj := rpc.M{
+		"encoding": solana.EncodingJSONParsed,
+	}
 	if opts != nil {
-		obj := make(rpc.M)
 		if opts.Commitment != "" {
 			obj["commitment"] = opts.Commitment
 		}
-		obj["encoding"] = solana.EncodingJSONParsed
 		if opts.TransactionDetails != "" {
 			obj["transactionDetails"] = opts.TransactionDetails
 		}
@@ -67,10 +70,8 @@ func (cl *Client) ParsedBlockSubscribe(
 		if opts.MaxSupportedTransactionVersion != nil {
 			obj["maxSupportedTransactionVersion"] = *opts.MaxSupportedTransactionVersion
 		}
-		if len(obj) > 0 {
-			params = append(params, obj)
-		}
 	}
+	params = append(params, obj)
 	genSub, err := cl.subscribe(
 		params,
 		nil,


### PR DESCRIPTION
## What

`ParsedBlockSubscribe` only builds its configuration object when the caller passes options:

```go
if opts != nil {
	obj := make(rpc.M)
	...
	obj["encoding"] = solana.EncodingJSONParsed
	...
	params = append(params, obj)
}
```

So `ParsedBlockSubscribe(filter, nil)` sends no configuration at all. The request on the wire is:

```json
{"jsonrpc":"2.0","method":"blockSubscribe","params":["all"],"id":1}
```

`blockSubscribe` then applies its own default of `base64`, and the notification arrives with `"transaction": ["<base64>", "base64"]` — a JSON array. The subscription decodes into `ParsedBlockResult`, whose `Transaction` is a `*ParsedTransaction` struct, so the decode fails and `handleSubscriptionMessage` closes the subscription on the first notification. The method never yields a block.

The `jsonParsed` encoding is the only thing separating this call from `BlockSubscribe`, so it is not really part of the optional configuration.

## Fix

Build the object unconditionally and append it once, which is what the equivalent HTTP method already does — `GetParsedBlockWithOpts` declares `obj := M{"encoding": solana.EncodingJSONParsed}` before its own `if opts != nil` (`rpc/getBlock.go`). `GetParsedTransaction` follows the same shape.

`BlockSubscribe` in the same file is deliberately left alone: its result type expects the server's `base64` default, so sending no configuration is correct there.

## Testing

Added `TestParsedBlockSubscribeSendsJSONParsedWithNilOpts` to `rpc/ws/blockSubscribe_test.go`, using the existing `mockWSServer` harness to capture the outgoing frame and assert the encoding is present. On current `main` it fails at the harness's own precondition:

```
"1" is not greater than or equal to "2"
expected opts object in params[1]: {"jsonrpc":"2.0","method":"blockSubscribe","params":["all"],"id":...}
```

Full `rpc/ws` suite passes with the change. No existing test asserted the old behaviour.
