### PR TITLE
fix(vault): reject ciphertext shorter than the salt and nonce prefix

### DIFF
--- a/vault/passphrase.go
+++ b/vault/passphrase.go
@@ -60,6 +60,9 @@ func (b *PassphraseBoxer) Open(in string) ([]byte, error) {
 	if err != nil {
 		return []byte{}, err
 	}
+	if len(buf) < saltLength+nonceLength {
+		return []byte{}, fmt.Errorf("invalid ciphertext: expected at least %d bytes, got %d", saltLength+nonceLength, len(buf))
+	}
 
 	salt := make([]byte, saltLength)
 	copy(salt, buf[:saltLength])

--- a/vault/passphrase_test.go
+++ b/vault/passphrase_test.go
@@ -1,0 +1,46 @@
+package vault
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPassphraseBoxer_SealOpen(t *testing.T) {
+	boxer := NewPassphraseBoxer("secret")
+
+	sealed, err := boxer.Seal([]byte("hello"))
+	require.NoError(t, err)
+
+	opened, err := boxer.Open(sealed)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("hello"), opened)
+}
+
+func TestPassphraseBoxer_OpenWrongPassphrase(t *testing.T) {
+	sealed, err := NewPassphraseBoxer("secret").Seal([]byte("hello"))
+	require.NoError(t, err)
+
+	_, err = NewPassphraseBoxer("wrong").Open(sealed)
+	require.Error(t, err)
+}
+
+func TestPassphraseBoxer_OpenShortCiphertext(t *testing.T) {
+	boxer := NewPassphraseBoxer("secret")
+
+	// Anything shorter than the salt and nonce prefix cannot be a sealed
+	// payload, and must be reported rather than sliced past the buffer.
+	for _, size := range []int{0, 1, saltLength, saltLength + nonceLength - 1} {
+		in := base64.RawStdEncoding.EncodeToString(make([]byte, size))
+
+		_, err := boxer.Open(in)
+		require.Error(t, err, "expected error for %d-byte ciphertext", size)
+	}
+}
+
+func TestPassphraseBoxer_OpenInvalidBase64(t *testing.T) {
+	_, err := NewPassphraseBoxer("secret").Open("!!!not-base64!!!")
+	require.Error(t, err)
+}


### PR DESCRIPTION
## What

`PassphraseBoxer.Open` slices the decoded buffer out to offset 40 (`saltLength` 16 + `nonceLength` 24) without checking how long it is:

```go
buf, err := base64.RawStdEncoding.DecodeString(in)
if err != nil {
	return []byte{}, err
}

salt := make([]byte, saltLength)
copy(salt, buf[:saltLength])
var nonce [nonceLength]byte
copy(nonce[:], buf[saltLength:nonceLength+saltLength])
```

`Seal` writes `salt || nonce || ciphertext`, so anything well-formed is comfortably longer than that — but nothing enforces it on the read path. A base64-valid string that decodes to fewer than 40 bytes panics:

```
panic: runtime error: slice bounds out of range [:16] with capacity 5
	vault/passphrase.go:65
```

This is reachable from ordinary use rather than only from direct API calls. `SecretBoxCiphertext` is a plain JSON field read off disk by `NewVaultFromWalletFile` with no validation, handed to the boxer by `Vault.Open`, and reached from `slnc` (`cmd/slnc/cmd/common.go`, `cmd/slnc/cmd/vault_add.go`). A truncated or corrupted wallet file crashes the command instead of reporting the `opening boxer: ...` error the caller is written to expect.

`KMSGCPBoxer.Open`, the other implementation of the same interface, wraps every failure path and never slices raw — this one is the outlier.

## Fix

Check the length before slicing, and report it.

## Testing

`vault/` had no test files at all, so this adds `vault/passphrase_test.go` covering the round trip, a wrong passphrase, invalid base64, and the short-ciphertext cases (0, 1, 16, and 39 bytes). The short-ciphertext test panics on current `main` and passes with the change.
