### PR TITLE
fix(text): honour DisableColors in YellowBG

### DIFF
--- a/text/tools.go
+++ b/text/tools.go
@@ -102,6 +102,9 @@ func Yellow(str string) string {
 }
 
 func YellowBG(str string) string {
+	if DisableColors {
+		return str
+	}
 	return Black(BgString(str, 255, 255, 0))
 }
 

--- a/text/tools_test.go
+++ b/text/tools_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 // TestColorHelpersRespectDisableColors pins that every exported color helper
-// honours the DisableColors escape hatch documented on Transaction.String.
+// honors the DisableColors escape hatch documented on Transaction.String.
 func TestColorHelpersRespectDisableColors(t *testing.T) {
 	old := DisableColors
 	DisableColors = true

--- a/text/tools_test.go
+++ b/text/tools_test.go
@@ -1,0 +1,40 @@
+package text
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestColorHelpersRespectDisableColors pins that every exported color helper
+// honours the DisableColors escape hatch documented on Transaction.String.
+func TestColorHelpersRespectDisableColors(t *testing.T) {
+	old := DisableColors
+	DisableColors = true
+	defer func() { DisableColors = old }()
+
+	helpers := map[string]func(string) string{
+		"Black":         Black,
+		"BlackBG":       BlackBG,
+		"White":         White,
+		"WhiteBG":       WhiteBG,
+		"Lime":          Lime,
+		"LimeBG":        LimeBG,
+		"Yellow":        Yellow,
+		"YellowBG":      YellowBG,
+		"Orange":        Orange,
+		"OrangeBG":      OrangeBG,
+		"Red":           Red,
+		"RedBG":         RedBG,
+		"Shakespeare":   Shakespeare,
+		"ShakespeareBG": ShakespeareBG,
+		"Purple":        Purple,
+		"PurpleBG":      PurpleBG,
+		"Indigo":        Indigo,
+		"IndigoBG":      IndigoBG,
+		"Bold":          Bold,
+	}
+	for name, fn := range helpers {
+		require.Equal(t, "sample", fn("sample"), "%s must return the input unchanged when DisableColors is set", name)
+	}
+}


### PR DESCRIPTION
## What

`text.DisableColors` is the documented way to turn colors off — `Transaction.String` says so directly:

```go
// String returns a human-readable string representation of the transaction data.
// To disable colors, set "github.com/gagliardetto/solana-go/text".DisableColors = true
```

Every exported color helper honours it except one:

```go
func YellowBG(str string) string {
	return Black(BgString(str, 255, 255, 0))
}
```

Its own counterpart `Yellow` has the guard, as do `BlackBG`, `WhiteBG`, `LimeBG`, `OrangeBG`, `RedBG`, `ShakespeareBG`, `PurpleBG`, `IndigoBG` and the rest — 19 of 20. `YellowBG` returns escape sequences into output the caller asked to be plain.

## Fix

Add the same guard the siblings use.

## Testing

`text/` had no test for this, so this adds a table test over every exported color helper asserting each returns its input unchanged when `DisableColors` is set. On current `main` exactly one entry fails:

```
YellowBG must return the input unchanged when DisableColors is set
```

which is the lone gap the table is there to catch. It passes with the change.

Small and cosmetic — happy to close it if you'd rather not carry the test.
