### PR TITLE
fix(keys): reject PDA-marker owner in CreateWithSeed

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -635,13 +635,14 @@ func CreateWithSeed(base PublicKey, seed string, owner PublicKey) (PublicKey, er
 		return PublicKey{}, ErrMaxSeedLengthExceeded
 	}
 
-	// let owner = owner.as_ref();
-	// if owner.len() >= PDA_MARKER.len() {
-	//     let slice = &owner[owner.len() - PDA_MARKER.len()..];
-	//     if slice == PDA_MARKER {
-	//         return Err(PubkeyError::IllegalOwner);
-	//     }
-	// }
+	// Reject an owner whose trailing bytes equal the PDA marker, mirroring
+	// solana-labs' Pubkey::create_with_seed. Without this an owner ending in
+	// PDA_MARKER lets create_with_seed produce an address that collides with a
+	// program-derived address for that owner.
+	if marker := []byte(PDA_MARKER); len(owner) >= len(marker) &&
+		bytes.Equal(owner[len(owner)-len(marker):], marker) {
+		return PublicKey{}, ErrIllegalOwner
+	}
 
 	b := make([]byte, 0, 64+len(seed))
 	b = append(b, base[:]...)
@@ -654,6 +655,10 @@ func CreateWithSeed(base PublicKey, seed string, owner PublicKey) (PublicKey, er
 const PDA_MARKER = "ProgramDerivedAddress"
 
 var ErrMaxSeedLengthExceeded = errors.New("max seed length exceeded")
+
+// ErrIllegalOwner is returned by CreateWithSeed when the owner ends with the
+// program-derived-address marker, which is disallowed.
+var ErrIllegalOwner = errors.New("provided owner is not allowed")
 
 // Create a program address.
 // Ported from https://github.com/solana-labs/solana/blob/216983c50e0a618facc39aa07472ba6d23f1b33a/sdk/program/src/pubkey.rs#L204

--- a/keys_test.go
+++ b/keys_test.go
@@ -23,6 +23,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"flag"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -490,6 +491,22 @@ func TestCreateWithSeed(t *testing.T) {
 		got, err := CreateWithSeed(PublicKey{}, "limber chicken: 4/45", PublicKey{})
 		require.NoError(t, err)
 		require.True(t, got.Equals(MustPublicKeyFromBase58("9h1HyLCW5dZnBVap8C5egQ9Z6pHyjsh5MNy83iPqqRuq")))
+	}
+	{
+		// An owner ending with the PDA marker must be rejected, matching
+		// solana-labs Pubkey::create_with_seed, so the derived address can
+		// never collide with a program-derived address.
+		var owner PublicKey
+		marker := []byte(PDA_MARKER)
+		copy(owner[PublicKeyLength-len(marker):], marker)
+
+		_, err := CreateWithSeed(PublicKey{}, "seed", owner)
+		require.ErrorIs(t, err, ErrIllegalOwner)
+	}
+	{
+		// A seed longer than MaxSeedLength is rejected.
+		_, err := CreateWithSeed(PublicKey{}, strings.Repeat("a", MaxSeedLength+1), PublicKey{})
+		require.ErrorIs(t, err, ErrMaxSeedLengthExceeded)
 	}
 }
 


### PR DESCRIPTION
Ports the `IllegalOwner` guard that `solana-labs` `Pubkey::create_with_seed` performs but which was left as a comment in `keys.go`.

`CreateWithSeed` now rejects an `owner` whose trailing bytes equal the PDA marker (`ProgramDerivedAddress`) with a new sentinel `ErrIllegalOwner`, so a `create_with_seed` address can never collide with a program-derived address for that owner. The legal-owner path is unchanged.

- Adds `ErrIllegalOwner`.
- Extends `TestCreateWithSeed` with the illegal-owner case (was silently accepted before) and a seed-too-long case.

Closes #469
