### PR TITLE
fix: reject IllegalOwner in CreateWithSeed when owner ends with PDA marker

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -635,13 +635,9 @@ func CreateWithSeed(base PublicKey, seed string, owner PublicKey) (PublicKey, er
 		return PublicKey{}, ErrMaxSeedLengthExceeded
 	}
 
-	// let owner = owner.as_ref();
-	// if owner.len() >= PDA_MARKER.len() {
-	//     let slice = &owner[owner.len() - PDA_MARKER.len()..];
-	//     if slice == PDA_MARKER {
-	//         return Err(PubkeyError::IllegalOwner);
-	//     }
-	// }
+	if string(owner[len(owner)-len(PDA_MARKER):]) == PDA_MARKER {
+		return PublicKey{}, ErrIllegalOwner
+	}
 
 	b := make([]byte, 0, 64+len(seed))
 	b = append(b, base[:]...)
@@ -654,6 +650,11 @@ func CreateWithSeed(base PublicKey, seed string, owner PublicKey) (PublicKey, er
 const PDA_MARKER = "ProgramDerivedAddress"
 
 var ErrMaxSeedLengthExceeded = errors.New("max seed length exceeded")
+
+// ErrIllegalOwner is returned by CreateWithSeed when the owner's trailing
+// bytes match the PDA marker, which would let the resulting address collide
+// with a program-derived address for that owner.
+var ErrIllegalOwner = errors.New("illegal owner")
 
 // Create a program address.
 // Ported from https://github.com/solana-labs/solana/blob/216983c50e0a618facc39aa07472ba6d23f1b33a/sdk/program/src/pubkey.rs#L204

--- a/keys_test.go
+++ b/keys_test.go
@@ -491,6 +491,13 @@ func TestCreateWithSeed(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, got.Equals(MustPublicKeyFromBase58("9h1HyLCW5dZnBVap8C5egQ9Z6pHyjsh5MNy83iPqqRuq")))
 	}
+	{
+		var owner PublicKey
+		copy(owner[len(owner)-len(PDA_MARKER):], PDA_MARKER)
+
+		_, err := CreateWithSeed(PublicKey{}, "seed", owner)
+		require.ErrorIs(t, err, ErrIllegalOwner)
+	}
 }
 
 func TestCreateProgramAddressFromRust(t *testing.T) {


### PR DESCRIPTION
## Summary
- `CreateWithSeed` did not reject an `owner` whose trailing bytes equal the PDA marker (`ProgramDerivedAddress`), even though the upstream `solana-labs` `Pubkey::create_with_seed` performs this `IllegalOwner` check. The check was present in `keys.go` only as a commented-out reference.
- Ports the check: if `owner`'s trailing bytes equal `PDA_MARKER`, `CreateWithSeed` now returns a new sentinel error, `ErrIllegalOwner`.
- Adds a regression test matching the issue's repro case.

Closes #469

## Test plan
- [x] `go test . -run TestCreateWithSeed -v`
- [x] `go vet .`