### PR TITLE
feat: serde token-2022 extensions

### DIFF
--- a/programs/token-2022/example_test.go
+++ b/programs/token-2022/example_test.go
@@ -1,0 +1,129 @@
+package token2022_test
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"log"
+
+	token2022 "github.com/gagliardetto/solana-go/programs/token-2022"
+)
+
+// xStockMintAccountData is the on-chain account data of the token-2022 mint
+// Xs3oZwbHvqis4NYcf4YKWmEia2eC84wSiVrcYcTqpH8 (SpaceX xStock), as returned by
+// getAccountInfo with base64 encoding. The mint carries eight extensions:
+// MetadataPointer, PermanentDelegate, DefaultAccountState, ScaledUiAmount,
+// Pausable, ConfidentialTransferMint, TransferHook, and TokenMetadata.
+const xStockMintAccountData = "AQAAAGVqQkIv6okUBqQZ0dHeCPQqhHlBtaGulevOYZrDFyk0XOODfu4yAAAIAQEAAAD/3+wbzSzTg5PITaoIyRzA041nf/jQq3tdAz8A9zLMMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARIAQABD+fHuLje4B+pFy3TmAJcivsAJKWAm5ORVi0NeJKXpxgfoA5u0rUz3nDg+Q8DFHdGFN0BRK3nQ+UISkjRR0AODDAAgAEP58e4uN7gH6kXLdOYAlyK+wAkpYCbk5FWLQ14kpenGBgABAAEZADgABm9ZIlHMR3R4JaWa0UIupDVz9SjaXe4q94ErMU+ZReMAAAAAAADwPwAAAAAAAAAAAAAAAAAA8D8aACEA/9/sG80s04OTyE2qCMkcwNONZ3/40Kt7XQM/APcyzDAABABBAEP58e4uN7gH6kXLdOYAlyK+wAkpYCbk5FWLQ14kpenGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADgBAAEP58e4uN7gH6kXLdOYAlyK+wAkpYCbk5FWLQ14kpenGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATAKYAQ/nx7i43uAfqRct05gCXIr7ACSlgJuTkVYtDXiSl6cYH6AObtK1M95w4PkPAxR3RhTdAUSt50PlCEpI0UdADgw0AAABTcGFjZVggeFN0b2NrBQAAAFNQQ1h4RAAAAGh0dHBzOi8veHN0b2Nrcy1tZXRhZGF0YS5iYWNrZWQuZmkvdG9rZW5zL1NvbGFuYS9TUENYeC9tZXRhZGF0YS5qc29uAAAAAA=="
+
+// Decode a real mainnet token-2022 mint into a typed struct, walk every one
+// of its eight extensions (in their on-chain TLV order), and re-encode the
+// account byte-exactly. Extension fields are nil when an extension is absent;
+// optional pubkeys inside extensions return nil from Get() when unset.
+func ExampleDecodeMintWithExtensions() {
+	data, err := base64.StdEncoding.DecodeString(xStockMintAccountData)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	mint, err := token2022.DecodeMintWithExtensions(data)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Base mint state (the same 82-byte layout as the original SPL token).
+	fmt.Println("== base mint ==")
+	fmt.Println("supply:", mint.Mint.Supply)
+	fmt.Println("decimals:", mint.Mint.Decimals)
+	fmt.Println("mint authority:", mint.Mint.MintAuthority)
+	fmt.Println("freeze authority:", mint.Mint.FreezeAuthority)
+
+	fmt.Println("== MetadataPointer ==")
+	fmt.Println("authority:", mint.MetadataPointer.Authority.Get())
+	fmt.Println("metadata address:", mint.MetadataPointer.MetadataAddress.Get())
+
+	fmt.Println("== PermanentDelegate ==")
+	fmt.Println("delegate:", mint.PermanentDelegate.Delegate.Get())
+
+	fmt.Println("== DefaultAccountState ==")
+	fmt.Println("state for new token accounts:", mint.DefaultAccountState.State)
+
+	fmt.Println("== ScaledUiAmount ==")
+	fmt.Println("authority:", mint.ScaledUiAmount.Authority.Get())
+	fmt.Println("multiplier:", mint.ScaledUiAmount.Multiplier)
+	fmt.Println("new multiplier:", mint.ScaledUiAmount.NewMultiplier,
+		"effective at unix time", mint.ScaledUiAmount.NewMultiplierEffectiveTimestamp)
+	// The extension also converts raw amounts to UI amounts (unix timestamp
+	// 0 already selects the new 1.0 multiplier here).
+	uiAmount, err := mint.ScaledUiAmount.AmountToUiAmount(mint.Mint.Supply, mint.Mint.Decimals, 0)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("ui supply:", uiAmount)
+
+	fmt.Println("== Pausable ==")
+	fmt.Println("authority:", mint.Pausable.Authority.Get())
+	fmt.Println("paused:", mint.Pausable.Paused)
+
+	fmt.Println("== ConfidentialTransferMint ==")
+	fmt.Println("authority:", mint.ConfidentialTransferMint.Authority.Get())
+	fmt.Println("auto approve new accounts:", mint.ConfidentialTransferMint.AutoApproveNewAccounts)
+	fmt.Println("auditor configured:", mint.ConfidentialTransferMint.AuditorElGamalPubkey != [32]byte{})
+
+	fmt.Println("== TransferHook ==")
+	fmt.Println("authority:", mint.TransferHook.Authority.Get())
+	fmt.Println("hook program:", mint.TransferHook.ProgramID.Get())
+
+	fmt.Println("== TokenMetadata ==")
+	fmt.Println("update authority:", mint.TokenMetadata.UpdateAuthority.Get())
+	fmt.Println("mint:", mint.TokenMetadata.Mint)
+	fmt.Println("name:", mint.TokenMetadata.Name)
+	fmt.Println("symbol:", mint.TokenMetadata.Symbol)
+	fmt.Println("uri:", mint.TokenMetadata.Uri)
+	fmt.Println("additional metadata fields:", len(mint.TokenMetadata.AdditionalMetadata))
+
+	// MarshalBinary reproduces the on-chain bytes exactly, preserving the
+	// original TLV extension order.
+	encoded, err := mint.MarshalBinary()
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("round-trip byte-exact:", bytes.Equal(encoded, data))
+
+	// Output:
+	// == base mint ==
+	// supply: 55999906177884
+	// decimals: 8
+	// mint authority: 7pt9tkctJPK7PPNQJ77GKg8ZffSF6QxoMiCFYHxrtaCj
+	// freeze authority: JDq14BWvqCRFNu1krb12bcRpbGtJZ1FLEakMw6FdxJNs
+	// == MetadataPointer ==
+	// authority: 5aMNNLQJwAEeoemTEMkv5NVjqKwvvefRYCQ5Z67HFvEq
+	// metadata address: Xs3oZwbHvqis4NYcf4YKWmEia2eC84wSiVrcYcTqpH8
+	// == PermanentDelegate ==
+	// delegate: 5aMNNLQJwAEeoemTEMkv5NVjqKwvvefRYCQ5Z67HFvEq
+	// == DefaultAccountState ==
+	// state for new token accounts: Initialized
+	// == ScaledUiAmount ==
+	// authority: S7vYFFWH6BjJyEsdrPQpqpYTqLTrPRK6KW3VwsJuRaS
+	// multiplier: 1
+	// new multiplier: 1 effective at unix time 0
+	// ui supply: 559999.06177884
+	// == Pausable ==
+	// authority: JDq14BWvqCRFNu1krb12bcRpbGtJZ1FLEakMw6FdxJNs
+	// paused: false
+	// == ConfidentialTransferMint ==
+	// authority: 5aMNNLQJwAEeoemTEMkv5NVjqKwvvefRYCQ5Z67HFvEq
+	// auto approve new accounts: false
+	// auditor configured: false
+	// == TransferHook ==
+	// authority: 5aMNNLQJwAEeoemTEMkv5NVjqKwvvefRYCQ5Z67HFvEq
+	// hook program: <nil>
+	// == TokenMetadata ==
+	// update authority: 5aMNNLQJwAEeoemTEMkv5NVjqKwvvefRYCQ5Z67HFvEq
+	// mint: Xs3oZwbHvqis4NYcf4YKWmEia2eC84wSiVrcYcTqpH8
+	// name: SpaceX xStock
+	// symbol: SPCXx
+	// uri: https://xstocks-metadata.backed.fi/tokens/Solana/SPCXx/metadata.json
+	// additional metadata fields: 0
+	// round-trip byte-exact: true
+}

--- a/programs/token-2022/extension_account.go
+++ b/programs/token-2022/extension_account.go
@@ -1,0 +1,620 @@
+package token2022
+
+import (
+	"bytes"
+	"encoding"
+	"encoding/binary"
+	"fmt"
+	"math"
+
+	bin "github.com/gagliardetto/binary"
+)
+
+// MintWithExtensions is a token-2022 mint together with its typed extensions.
+// Extension pointer fields are nil when the extension is absent; boolean
+// fields represent zero-length marker extensions. Unrecognized extension
+// types are preserved verbatim in Unknown so that data written by newer
+// program versions survives a decode/encode round-trip.
+type MintWithExtensions struct {
+	Mint Mint
+
+	TransferFeeConfig             *TransferFeeConfigState
+	MintCloseAuthority            *MintCloseAuthorityState
+	ConfidentialTransferMint      *ConfidentialTransferMintState
+	DefaultAccountState           *DefaultAccountStateConfig
+	NonTransferable               bool
+	InterestBearingConfig         *InterestBearingConfigState
+	PermanentDelegate             *PermanentDelegateState
+	TransferHook                  *TransferHookState
+	ConfidentialTransferFeeConfig *ConfidentialTransferFeeConfigState
+	MetadataPointer               *MetadataPointerState
+	TokenMetadata                 *TokenMetadataState
+	GroupPointer                  *GroupPointerState
+	TokenGroup                    *TokenGroup
+	GroupMemberPointer            *GroupMemberPointerState
+	TokenGroupMember              *TokenGroupMember
+	ConfidentialMintBurn          *ConfidentialMintBurnState
+	ScaledUiAmount                *ScaledUiAmountState
+	Pausable                      *PausableState
+	PermissionedBurn              *PermissionedBurnState
+
+	// Unknown holds TLV entries with unrecognized extension types, in their
+	// original order.
+	Unknown []ExtensionTLV
+
+	// tlvOrder is the original TLV entry order captured at decode time, used
+	// to re-encode byte-exactly.
+	tlvOrder []ExtensionType
+}
+
+// AccountWithExtensions is a token-2022 token account together with its typed
+// extensions. See MintWithExtensions for the field conventions.
+type AccountWithExtensions struct {
+	Account Account
+
+	TransferFeeAmount             *TransferFeeAmountState
+	ConfidentialTransferAccount   *ConfidentialTransferAccountState
+	ImmutableOwner                bool
+	MemoTransfer                  *MemoTransferState
+	CpiGuard                      *CpiGuardState
+	NonTransferableAccount        bool
+	TransferHookAccount           *TransferHookAccountState
+	ConfidentialTransferFeeAmount *ConfidentialTransferFeeAmountState
+	PausableAccount               bool
+
+	// Unknown holds TLV entries with unrecognized extension types, in their
+	// original order.
+	Unknown []ExtensionTLV
+
+	// tlvOrder is the original TLV entry order captured at decode time, used
+	// to re-encode byte-exactly.
+	tlvOrder []ExtensionType
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*MintWithExtensions)(nil)
+	_ encoding.BinaryUnmarshaler = (*MintWithExtensions)(nil)
+	_ encoding.BinaryMarshaler   = (*AccountWithExtensions)(nil)
+	_ encoding.BinaryUnmarshaler = (*AccountWithExtensions)(nil)
+)
+
+// DecodeMintWithExtensions decodes a token-2022 mint account, including all
+// extensions, from raw account data.
+func DecodeMintWithExtensions(data []byte) (*MintWithExtensions, error) {
+	m := new(MintWithExtensions)
+	if err := m.UnmarshalBinary(data); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// DecodeAccountWithExtensions decodes a token-2022 token account, including
+// all extensions, from raw account data.
+func DecodeAccountWithExtensions(data []byte) (*AccountWithExtensions, error) {
+	a := new(AccountWithExtensions)
+	if err := a.UnmarshalBinary(data); err != nil {
+		return nil, err
+	}
+	return a, nil
+}
+
+// splitExtensionRegion validates the layout of extended account data and
+// returns the TLV region (nil when the data is exactly the base state).
+//
+// Rules, mirroring the token-2022 program: data shorter than the base state
+// is invalid; data of exactly the base length carries no extensions; data of
+// exactly 355 bytes is never valid (that length is reserved for multisig
+// accounts); extended data must reach past offset 166, have zero padding
+// between the base state and offset 165 (relevant for mints), and carry the
+// expected account type byte at offset 165.
+func splitExtensionRegion(data []byte, baseSize int, wantAccountType uint8) ([]byte, error) {
+	if len(data) < baseSize {
+		return nil, fmt.Errorf("%w: %d bytes is shorter than the base state (%d)", ErrInvalidAccountData, len(data), baseSize)
+	}
+	if len(data) == baseSize {
+		return nil, nil
+	}
+	if len(data) == multisigSize {
+		return nil, fmt.Errorf("%w: %d bytes is the multisig length, not valid extended state", ErrInvalidAccountData, len(data))
+	}
+	if len(data) < tlvStartOffset {
+		return nil, fmt.Errorf("%w: %d bytes is too short for extended state (need at least %d)", ErrInvalidAccountData, len(data), tlvStartOffset)
+	}
+	for i := baseSize; i < accountTypeOffset; i++ {
+		if data[i] != 0 {
+			return nil, fmt.Errorf("%w: nonzero padding byte at offset %d", ErrInvalidAccountData, i)
+		}
+	}
+	if data[accountTypeOffset] != wantAccountType {
+		return nil, fmt.Errorf("%w: account type byte is %d, want %d", ErrInvalidAccountData, data[accountTypeOffset], wantAccountType)
+	}
+	return data[tlvStartOffset:], nil
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler. It decodes full mint
+// account data, validating the extension layout strictly (see
+// splitExtensionRegion) and rejecting uninitialized mints, account-side
+// extensions, duplicate extensions, and length mismatches.
+func (m *MintWithExtensions) UnmarshalBinary(data []byte) error {
+	*m = MintWithExtensions{}
+	tlvRegion, err := splitExtensionRegion(data, MINT_SIZE, AccountTypeMint)
+	if err != nil {
+		return err
+	}
+	if err := m.Mint.UnmarshalWithDecoder(bin.NewBinDecoder(data)); err != nil {
+		return fmt.Errorf("unable to decode mint: %w", err)
+	}
+	if !m.Mint.IsInitialized {
+		return fmt.Errorf("%w: mint is_initialized is false", ErrUninitializedAccount)
+	}
+	if tlvRegion == nil {
+		return nil
+	}
+	tlvs, err := ParseExtensions(tlvRegion)
+	if err != nil {
+		return err
+	}
+	for _, tlv := range tlvs {
+		if err := m.applyExtension(tlv); err != nil {
+			return err
+		}
+		m.tlvOrder = append(m.tlvOrder, tlv.Type)
+	}
+	return nil
+}
+
+func (m *MintWithExtensions) applyExtension(tlv ExtensionTLV) error {
+	info, known := extensionInfos[tlv.Type]
+	if !known {
+		m.Unknown = append(m.Unknown, tlv)
+		return nil
+	}
+	if !info.mint {
+		return fmt.Errorf("%w: %s is not a mint extension", ErrExtensionTypeMismatch, tlv.Type)
+	}
+	var err error
+	switch tlv.Type {
+	case ExtensionTransferFeeConfig:
+		err = decodeUniqueExtension(tlv, &m.TransferFeeConfig, DecodeTransferFeeConfigState)
+	case ExtensionMintCloseAuthority:
+		err = decodeUniqueExtension(tlv, &m.MintCloseAuthority, DecodeMintCloseAuthorityState)
+	case ExtensionConfidentialTransferMint:
+		err = decodeUniqueExtension(tlv, &m.ConfidentialTransferMint, DecodeConfidentialTransferMintState)
+	case ExtensionDefaultAccountState:
+		err = decodeUniqueExtension(tlv, &m.DefaultAccountState, DecodeDefaultAccountStateConfig)
+	case ExtensionNonTransferable:
+		err = applyMarkerExtension(tlv, &m.NonTransferable)
+	case ExtensionInterestBearingConfig:
+		err = decodeUniqueExtension(tlv, &m.InterestBearingConfig, DecodeInterestBearingConfigState)
+	case ExtensionPermanentDelegate:
+		err = decodeUniqueExtension(tlv, &m.PermanentDelegate, DecodePermanentDelegateState)
+	case ExtensionTransferHook:
+		err = decodeUniqueExtension(tlv, &m.TransferHook, DecodeTransferHookState)
+	case ExtensionConfidentialTransferFeeConfig:
+		err = decodeUniqueExtension(tlv, &m.ConfidentialTransferFeeConfig, DecodeConfidentialTransferFeeConfigState)
+	case ExtensionMetadataPointer:
+		err = decodeUniqueExtension(tlv, &m.MetadataPointer, DecodeMetadataPointerState)
+	case ExtensionTokenMetadata:
+		err = decodeUniqueExtension(tlv, &m.TokenMetadata, DecodeTokenMetadataState)
+	case ExtensionGroupPointer:
+		err = decodeUniqueExtension(tlv, &m.GroupPointer, DecodeGroupPointerState)
+	case ExtensionTokenGroup:
+		err = decodeUniqueExtension(tlv, &m.TokenGroup, DecodeTokenGroup)
+	case ExtensionGroupMemberPointer:
+		err = decodeUniqueExtension(tlv, &m.GroupMemberPointer, DecodeGroupMemberPointerState)
+	case ExtensionTokenGroupMember:
+		err = decodeUniqueExtension(tlv, &m.TokenGroupMember, DecodeTokenGroupMember)
+	case ExtensionConfidentialMintBurn:
+		err = decodeUniqueExtension(tlv, &m.ConfidentialMintBurn, DecodeConfidentialMintBurnState)
+	case ExtensionScaledUiAmount:
+		err = decodeUniqueExtension(tlv, &m.ScaledUiAmount, DecodeScaledUiAmountState)
+	case ExtensionPausable:
+		err = decodeUniqueExtension(tlv, &m.Pausable, DecodePausableState)
+	case ExtensionPermissionedBurn:
+		err = decodeUniqueExtension(tlv, &m.PermissionedBurn, DecodePermissionedBurnState)
+	default:
+		// Known but not a mint extension: unreachable (filtered above).
+		err = fmt.Errorf("%w: unsupported mint extension %s", ErrInvalidAccountData, tlv.Type)
+	}
+	return err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler. It decodes full
+// token account data with the same strictness as its mint counterpart
+// (accounts whose state is neither Initialized nor Frozen are rejected).
+func (a *AccountWithExtensions) UnmarshalBinary(data []byte) error {
+	*a = AccountWithExtensions{}
+	tlvRegion, err := splitExtensionRegion(data, ACCOUNT_SIZE, AccountTypeAccount)
+	if err != nil {
+		return err
+	}
+	if err := a.Account.UnmarshalWithDecoder(bin.NewBinDecoder(data)); err != nil {
+		return fmt.Errorf("unable to decode account: %w", err)
+	}
+	// Mirrors PodAccount::is_initialized: only Initialized and Frozen count.
+	if a.Account.State != AccountStateInitialized && a.Account.State != AccountStateFrozen {
+		return fmt.Errorf("%w: account state is %d", ErrUninitializedAccount, a.Account.State)
+	}
+	if tlvRegion == nil {
+		return nil
+	}
+	tlvs, err := ParseExtensions(tlvRegion)
+	if err != nil {
+		return err
+	}
+	for _, tlv := range tlvs {
+		if err := a.applyExtension(tlv); err != nil {
+			return err
+		}
+		a.tlvOrder = append(a.tlvOrder, tlv.Type)
+	}
+	return nil
+}
+
+func (a *AccountWithExtensions) applyExtension(tlv ExtensionTLV) error {
+	info, known := extensionInfos[tlv.Type]
+	if !known {
+		a.Unknown = append(a.Unknown, tlv)
+		return nil
+	}
+	if !info.account {
+		return fmt.Errorf("%w: %s is not a token-account extension", ErrExtensionTypeMismatch, tlv.Type)
+	}
+	var err error
+	switch tlv.Type {
+	case ExtensionTransferFeeAmount:
+		err = decodeUniqueExtension(tlv, &a.TransferFeeAmount, DecodeTransferFeeAmountState)
+	case ExtensionConfidentialTransferAccount:
+		err = decodeUniqueExtension(tlv, &a.ConfidentialTransferAccount, DecodeConfidentialTransferAccountState)
+	case ExtensionImmutableOwner:
+		err = applyMarkerExtension(tlv, &a.ImmutableOwner)
+	case ExtensionMemoTransfer:
+		err = decodeUniqueExtension(tlv, &a.MemoTransfer, DecodeMemoTransferState)
+	case ExtensionCpiGuard:
+		err = decodeUniqueExtension(tlv, &a.CpiGuard, DecodeCpiGuardState)
+	case ExtensionNonTransferableAccount:
+		err = applyMarkerExtension(tlv, &a.NonTransferableAccount)
+	case ExtensionTransferHookAccount:
+		err = decodeUniqueExtension(tlv, &a.TransferHookAccount, DecodeTransferHookAccountState)
+	case ExtensionConfidentialTransferFeeAmount:
+		err = decodeUniqueExtension(tlv, &a.ConfidentialTransferFeeAmount, DecodeConfidentialTransferFeeAmountState)
+	case ExtensionPausableAccount:
+		err = applyMarkerExtension(tlv, &a.PausableAccount)
+	default:
+		err = fmt.Errorf("%w: unsupported token-account extension %s", ErrInvalidAccountData, tlv.Type)
+	}
+	return err
+}
+
+// decodeUniqueExtension decodes tlv.Data into *dst, rejecting duplicates.
+func decodeUniqueExtension[T any](tlv ExtensionTLV, dst **T, decode func([]byte) (*T, error)) error {
+	if *dst != nil {
+		return fmt.Errorf("%w: %s", ErrDuplicateExtension, tlv.Type)
+	}
+	v, err := decode(tlv.Data)
+	if err != nil {
+		return err
+	}
+	*dst = v
+	return nil
+}
+
+// applyMarkerExtension records a zero-length marker extension, rejecting
+// duplicates and nonzero lengths.
+func applyMarkerExtension(tlv ExtensionTLV, dst *bool) error {
+	if *dst {
+		return fmt.Errorf("%w: %s", ErrDuplicateExtension, tlv.Type)
+	}
+	if tlv.Length != 0 {
+		return fmt.Errorf("%w: marker extension %s has length %d, want 0", ErrInvalidExtensionLength, tlv.Type, tlv.Length)
+	}
+	*dst = true
+	return nil
+}
+
+// HasExtensions reports whether any extension (including unknown ones) is set.
+func (m *MintWithExtensions) HasExtensions() bool {
+	return m.TransferFeeConfig != nil ||
+		m.MintCloseAuthority != nil ||
+		m.ConfidentialTransferMint != nil ||
+		m.DefaultAccountState != nil ||
+		m.NonTransferable ||
+		m.InterestBearingConfig != nil ||
+		m.PermanentDelegate != nil ||
+		m.TransferHook != nil ||
+		m.ConfidentialTransferFeeConfig != nil ||
+		m.MetadataPointer != nil ||
+		m.TokenMetadata != nil ||
+		m.GroupPointer != nil ||
+		m.TokenGroup != nil ||
+		m.GroupMemberPointer != nil ||
+		m.TokenGroupMember != nil ||
+		m.ConfidentialMintBurn != nil ||
+		m.ScaledUiAmount != nil ||
+		m.Pausable != nil ||
+		m.PermissionedBurn != nil ||
+		len(m.Unknown) > 0
+}
+
+// HasExtensions reports whether any extension (including unknown ones) is set.
+func (a *AccountWithExtensions) HasExtensions() bool {
+	return a.TransferFeeAmount != nil ||
+		a.ConfidentialTransferAccount != nil ||
+		a.ImmutableOwner ||
+		a.MemoTransfer != nil ||
+		a.CpiGuard != nil ||
+		a.NonTransferableAccount ||
+		a.TransferHookAccount != nil ||
+		a.ConfidentialTransferFeeAmount != nil ||
+		a.PausableAccount ||
+		len(a.Unknown) > 0
+}
+
+// presentExtensionTypes returns the set typed extensions in ascending
+// ExtensionType order.
+func (m *MintWithExtensions) presentExtensionTypes() []ExtensionType {
+	var out []ExtensionType
+	add := func(t ExtensionType, set bool) {
+		if set {
+			out = append(out, t)
+		}
+	}
+	add(ExtensionTransferFeeConfig, m.TransferFeeConfig != nil)
+	add(ExtensionMintCloseAuthority, m.MintCloseAuthority != nil)
+	add(ExtensionConfidentialTransferMint, m.ConfidentialTransferMint != nil)
+	add(ExtensionDefaultAccountState, m.DefaultAccountState != nil)
+	add(ExtensionNonTransferable, m.NonTransferable)
+	add(ExtensionInterestBearingConfig, m.InterestBearingConfig != nil)
+	add(ExtensionPermanentDelegate, m.PermanentDelegate != nil)
+	add(ExtensionTransferHook, m.TransferHook != nil)
+	add(ExtensionConfidentialTransferFeeConfig, m.ConfidentialTransferFeeConfig != nil)
+	add(ExtensionMetadataPointer, m.MetadataPointer != nil)
+	add(ExtensionTokenMetadata, m.TokenMetadata != nil)
+	add(ExtensionGroupPointer, m.GroupPointer != nil)
+	add(ExtensionTokenGroup, m.TokenGroup != nil)
+	add(ExtensionGroupMemberPointer, m.GroupMemberPointer != nil)
+	add(ExtensionTokenGroupMember, m.TokenGroupMember != nil)
+	add(ExtensionConfidentialMintBurn, m.ConfidentialMintBurn != nil)
+	add(ExtensionScaledUiAmount, m.ScaledUiAmount != nil)
+	add(ExtensionPausable, m.Pausable != nil)
+	add(ExtensionPermissionedBurn, m.PermissionedBurn != nil)
+	return out
+}
+
+// presentExtensionTypes returns the set typed extensions in ascending
+// ExtensionType order.
+func (a *AccountWithExtensions) presentExtensionTypes() []ExtensionType {
+	var out []ExtensionType
+	add := func(t ExtensionType, set bool) {
+		if set {
+			out = append(out, t)
+		}
+	}
+	add(ExtensionTransferFeeAmount, a.TransferFeeAmount != nil)
+	add(ExtensionConfidentialTransferAccount, a.ConfidentialTransferAccount != nil)
+	add(ExtensionImmutableOwner, a.ImmutableOwner)
+	add(ExtensionMemoTransfer, a.MemoTransfer != nil)
+	add(ExtensionCpiGuard, a.CpiGuard != nil)
+	add(ExtensionNonTransferableAccount, a.NonTransferableAccount)
+	add(ExtensionTransferHookAccount, a.TransferHookAccount != nil)
+	add(ExtensionConfidentialTransferFeeAmount, a.ConfidentialTransferFeeAmount != nil)
+	add(ExtensionPausableAccount, a.PausableAccount)
+	return out
+}
+
+// extensionPayload marshals the typed extension t into its wire bytes.
+// present is false when the extension is not set. Marker extensions yield an
+// empty payload.
+func (m *MintWithExtensions) extensionPayload(t ExtensionType) (payload []byte, present bool, err error) {
+	switch t {
+	case ExtensionTransferFeeConfig:
+		return marshalOptionalExtension(m.TransferFeeConfig)
+	case ExtensionMintCloseAuthority:
+		return marshalOptionalExtension(m.MintCloseAuthority)
+	case ExtensionConfidentialTransferMint:
+		return marshalOptionalExtension(m.ConfidentialTransferMint)
+	case ExtensionDefaultAccountState:
+		return marshalOptionalExtension(m.DefaultAccountState)
+	case ExtensionNonTransferable:
+		return []byte{}, m.NonTransferable, nil
+	case ExtensionInterestBearingConfig:
+		return marshalOptionalExtension(m.InterestBearingConfig)
+	case ExtensionPermanentDelegate:
+		return marshalOptionalExtension(m.PermanentDelegate)
+	case ExtensionTransferHook:
+		return marshalOptionalExtension(m.TransferHook)
+	case ExtensionConfidentialTransferFeeConfig:
+		return marshalOptionalExtension(m.ConfidentialTransferFeeConfig)
+	case ExtensionMetadataPointer:
+		return marshalOptionalExtension(m.MetadataPointer)
+	case ExtensionTokenMetadata:
+		return marshalOptionalExtension(m.TokenMetadata)
+	case ExtensionGroupPointer:
+		return marshalOptionalExtension(m.GroupPointer)
+	case ExtensionTokenGroup:
+		return marshalOptionalExtension(m.TokenGroup)
+	case ExtensionGroupMemberPointer:
+		return marshalOptionalExtension(m.GroupMemberPointer)
+	case ExtensionTokenGroupMember:
+		return marshalOptionalExtension(m.TokenGroupMember)
+	case ExtensionConfidentialMintBurn:
+		return marshalOptionalExtension(m.ConfidentialMintBurn)
+	case ExtensionScaledUiAmount:
+		return marshalOptionalExtension(m.ScaledUiAmount)
+	case ExtensionPausable:
+		return marshalOptionalExtension(m.Pausable)
+	case ExtensionPermissionedBurn:
+		return marshalOptionalExtension(m.PermissionedBurn)
+	default:
+		return nil, false, nil
+	}
+}
+
+// extensionPayload marshals the typed extension t into its wire bytes.
+func (a *AccountWithExtensions) extensionPayload(t ExtensionType) (payload []byte, present bool, err error) {
+	switch t {
+	case ExtensionTransferFeeAmount:
+		return marshalOptionalExtension(a.TransferFeeAmount)
+	case ExtensionConfidentialTransferAccount:
+		return marshalOptionalExtension(a.ConfidentialTransferAccount)
+	case ExtensionImmutableOwner:
+		return []byte{}, a.ImmutableOwner, nil
+	case ExtensionMemoTransfer:
+		return marshalOptionalExtension(a.MemoTransfer)
+	case ExtensionCpiGuard:
+		return marshalOptionalExtension(a.CpiGuard)
+	case ExtensionNonTransferableAccount:
+		return []byte{}, a.NonTransferableAccount, nil
+	case ExtensionTransferHookAccount:
+		return marshalOptionalExtension(a.TransferHookAccount)
+	case ExtensionConfidentialTransferFeeAmount:
+		return marshalOptionalExtension(a.ConfidentialTransferFeeAmount)
+	case ExtensionPausableAccount:
+		return []byte{}, a.PausableAccount, nil
+	default:
+		return nil, false, nil
+	}
+}
+
+// marshalOptionalExtension marshals a possibly-nil extension state pointer.
+func marshalOptionalExtension[T any, PT interface {
+	*T
+	bin.BinaryMarshaler
+}](s *T) ([]byte, bool, error) {
+	if s == nil {
+		return nil, false, nil
+	}
+	buf := new(bytes.Buffer)
+	if err := PT(s).MarshalWithEncoder(bin.NewBinEncoder(buf)); err != nil {
+		return nil, false, err
+	}
+	return buf.Bytes(), true, nil
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler. It produces byte-exact
+// token-2022 mint account data: the 82-byte base state alone when no
+// extensions are set, otherwise base state, zero padding to offset 165, the
+// account type byte, and the TLV entries. Extensions decoded from existing
+// data keep their original TLV order; extensions added afterwards (or set on
+// a hand-built value) are appended in ascending ExtensionType order. If the
+// resulting data would be exactly 355 bytes long (the multisig length), two
+// zero bytes are appended, as done by the token-2022 program.
+func (m *MintWithExtensions) MarshalBinary() ([]byte, error) {
+	base := new(bytes.Buffer)
+	if err := m.Mint.MarshalWithEncoder(bin.NewBinEncoder(base)); err != nil {
+		return nil, fmt.Errorf("unable to encode mint: %w", err)
+	}
+	return encodeWithExtensions(base.Bytes(), MINT_SIZE, AccountTypeMint, m.tlvOrder, m.presentExtensionTypes(), m.Unknown, m.extensionPayload)
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler. See the documentation
+// on MintWithExtensions.MarshalBinary for the exact semantics.
+func (a *AccountWithExtensions) MarshalBinary() ([]byte, error) {
+	base := new(bytes.Buffer)
+	if err := a.Account.MarshalWithEncoder(bin.NewBinEncoder(base)); err != nil {
+		return nil, fmt.Errorf("unable to encode account: %w", err)
+	}
+	return encodeWithExtensions(base.Bytes(), ACCOUNT_SIZE, AccountTypeAccount, a.tlvOrder, a.presentExtensionTypes(), a.Unknown, a.extensionPayload)
+}
+
+// encodeWithExtensions assembles full account data from the base state bytes
+// and the extension payload source. Entries listed in tlvOrder are written
+// first (in that order, skipping ones no longer set); remaining present
+// extensions follow in ascending type order; remaining unknown TLVs are
+// written last in their stored order.
+func encodeWithExtensions(
+	base []byte,
+	baseSize int,
+	accountType uint8,
+	tlvOrder []ExtensionType,
+	present []ExtensionType,
+	unknown []ExtensionTLV,
+	payloadOf func(ExtensionType) ([]byte, bool, error),
+) ([]byte, error) {
+	if len(base) != baseSize {
+		return nil, fmt.Errorf("%w: base state encoded to %d bytes, want %d", ErrInvalidAccountData, len(base), baseSize)
+	}
+	if len(present) == 0 && len(unknown) == 0 {
+		return base, nil
+	}
+
+	out := new(bytes.Buffer)
+	out.Write(base)
+	out.Write(make([]byte, accountTypeOffset-baseSize))
+	out.WriteByte(accountType)
+
+	writeEntry := func(t ExtensionType, payload []byte) error {
+		if len(payload) > math.MaxUint16 {
+			return fmt.Errorf("%w: %s payload is %d bytes, exceeds the u16 TLV length", ErrInvalidExtensionLength, t, len(payload))
+		}
+		var header [4]byte
+		binary.LittleEndian.PutUint16(header[0:], uint16(t))
+		binary.LittleEndian.PutUint16(header[2:], uint16(len(payload)))
+		out.Write(header[:])
+		out.Write(payload)
+		return nil
+	}
+
+	written := make(map[ExtensionType]struct{}, len(present))
+	unknownIdx := 0
+
+	// First pass: original TLV order. Unknown entries are consumed from the
+	// Unknown slice in order; each entry is written with its own type and
+	// data so the pair stays consistent even if the caller edited Unknown
+	// after decoding.
+	for _, t := range tlvOrder {
+		if _, known := extensionInfos[t]; !known {
+			if unknownIdx < len(unknown) {
+				if err := writeEntry(unknown[unknownIdx].Type, unknown[unknownIdx].Data); err != nil {
+					return nil, err
+				}
+				unknownIdx++
+			}
+			continue
+		}
+		if _, done := written[t]; done {
+			continue
+		}
+		payload, ok, err := payloadOf(t)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue // extension was cleared after decoding
+		}
+		if err := writeEntry(t, payload); err != nil {
+			return nil, err
+		}
+		written[t] = struct{}{}
+	}
+
+	// Second pass: newly set extensions, ascending type order.
+	for _, t := range present {
+		if _, done := written[t]; done {
+			continue
+		}
+		payload, ok, err := payloadOf(t)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		if err := writeEntry(t, payload); err != nil {
+			return nil, err
+		}
+		written[t] = struct{}{}
+	}
+
+	// Remaining unknown TLVs not covered by tlvOrder.
+	for ; unknownIdx < len(unknown); unknownIdx++ {
+		if err := writeEntry(unknown[unknownIdx].Type, unknown[unknownIdx].Data); err != nil {
+			return nil, err
+		}
+	}
+
+	if out.Len() == multisigSize {
+		out.Write([]byte{0, 0})
+	}
+	return out.Bytes(), nil
+}

--- a/programs/token-2022/extension_account_test.go
+++ b/programs/token-2022/extension_account_test.go
@@ -1,0 +1,323 @@
+package token2022
+
+import (
+	"testing"
+
+	ag_require "github.com/stretchr/testify/require"
+)
+
+// tlvEntry builds one TLV entry: u16 LE type, u16 LE length, payload.
+func tlvEntry(t ExtensionType, payload []byte) []byte {
+	return concat(u16LE(uint16(t)), u16LE(uint16(len(payload))), payload)
+}
+
+// extendedMintData assembles full mint account data: base mint, zero padding
+// to offset 165, the mint account type byte, and the given TLV entries.
+func extendedMintData(entries ...[]byte) []byte {
+	data := concat(testMintSlice, repeatByte(0, ACCOUNT_SIZE-MINT_SIZE), []byte{AccountTypeMint})
+	return concat(append([][]byte{data}, entries...)...)
+}
+
+// extendedAccountData assembles full token account data: base account, the
+// account type byte, and the given TLV entries.
+func extendedAccountData(entries ...[]byte) []byte {
+	data := concat(testAccountSlice, []byte{AccountTypeAccount})
+	return concat(append([][]byte{data}, entries...)...)
+}
+
+func TestDecodeMintWithExtensions_BaseOnly(t *testing.T) {
+	m, err := DecodeMintWithExtensions(testMintSlice)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, uint64(42), m.Mint.Supply)
+	ag_require.False(t, m.HasExtensions())
+
+	out, err := m.MarshalBinary()
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, testMintSlice, out)
+}
+
+func TestDecodeAccountWithExtensions_BaseOnly(t *testing.T) {
+	a, err := DecodeAccountWithExtensions(testAccountSlice)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, uint64(3), a.Account.Amount)
+	ag_require.False(t, a.HasExtensions())
+
+	out, err := a.MarshalBinary()
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, testAccountSlice, out)
+}
+
+func TestRoundTrip_MintWithExtensions(t *testing.T) {
+	authority := pubkeyOf(0x0A)
+	metadata := TokenMetadataState{
+		UpdateAuthority: NewOptionalPubkey(&authority),
+		Mint:            pubkeyOf(0x0B),
+		Name:            "Example",
+		Symbol:          "EXM",
+		Uri:             "https://example.com/meta.json",
+		AdditionalMetadata: []MetadataField{
+			{Key: "kind", Value: "test"},
+		},
+	}
+	metadataPayload := marshalStateBytes(t, metadata)
+
+	// Deliberately non-ascending TLV order, with an unknown extension type
+	// in the middle, followed by a zeroed tail (realloc slack).
+	data := extendedMintData(
+		tlvEntry(ExtensionMetadataPointer, concat(repeatByte(0xC1, 32), repeatByte(0xC2, 32))),
+		tlvEntry(ExtensionType(999), []byte{9, 9, 9, 9, 9}),
+		tlvEntry(ExtensionTransferFeeConfig, concat(
+			repeatByte(0x11, 32), repeatByte(0x22, 32), u64LE(777),
+			u64LE(5), u64LE(1000), u16LE(50),
+			u64LE(6), u64LE(2000), u16LE(75),
+		)),
+		tlvEntry(ExtensionNonTransferable, nil),
+		tlvEntry(ExtensionTokenMetadata, metadataPayload),
+		repeatByte(0, 6),
+	)
+
+	m, err := DecodeMintWithExtensions(data)
+	ag_require.NoError(t, err)
+	ag_require.True(t, m.HasExtensions())
+
+	ag_require.NotNil(t, m.MetadataPointer)
+	ag_require.Equal(t, pubkeyOf(0xC1), m.MetadataPointer.Authority.Key)
+	ag_require.Equal(t, pubkeyOf(0xC2), m.MetadataPointer.MetadataAddress.Key)
+
+	ag_require.NotNil(t, m.TransferFeeConfig)
+	ag_require.Equal(t, uint64(777), m.TransferFeeConfig.WithheldAmount)
+	ag_require.Equal(t, uint16(75), m.TransferFeeConfig.NewerTransferFee.TransferFeeBasisPoints)
+
+	ag_require.True(t, m.NonTransferable)
+
+	ag_require.NotNil(t, m.TokenMetadata)
+	ag_require.Equal(t, "Example", m.TokenMetadata.Name)
+	ag_require.Equal(t, metadata.AdditionalMetadata, m.TokenMetadata.AdditionalMetadata)
+
+	ag_require.Len(t, m.Unknown, 1)
+	ag_require.Equal(t, ExtensionType(999), m.Unknown[0].Type)
+	ag_require.Equal(t, []byte{9, 9, 9, 9, 9}, m.Unknown[0].Data)
+
+	// Byte-exact re-encode preserves the original non-ascending TLV order
+	// and the unknown entry. The zeroed tail is not reproduced (it is
+	// decode-tolerated slack, not TLV content).
+	out, err := m.MarshalBinary()
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, data[:len(data)-6], out)
+
+	// Decoding the re-encoded bytes yields the same result.
+	m2, err := DecodeMintWithExtensions(out)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, m, m2)
+}
+
+func TestRoundTrip_AccountWithExtensions(t *testing.T) {
+	data := extendedAccountData(
+		tlvEntry(ExtensionCpiGuard, []byte{1}),
+		tlvEntry(ExtensionImmutableOwner, nil),
+		tlvEntry(ExtensionTransferFeeAmount, u64LE(123456789)),
+	)
+
+	a, err := DecodeAccountWithExtensions(data)
+	ag_require.NoError(t, err)
+	ag_require.True(t, a.HasExtensions())
+	ag_require.NotNil(t, a.CpiGuard)
+	ag_require.True(t, a.CpiGuard.LockCpi)
+	ag_require.True(t, a.ImmutableOwner)
+	ag_require.NotNil(t, a.TransferFeeAmount)
+	ag_require.Equal(t, uint64(123456789), a.TransferFeeAmount.WithheldAmount)
+	ag_require.False(t, a.NonTransferableAccount)
+	ag_require.False(t, a.PausableAccount)
+
+	out, err := a.MarshalBinary()
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, data, out)
+}
+
+func TestDecodeMintWithExtensions_Strictness(t *testing.T) {
+	valid := extendedMintData(tlvEntry(ExtensionMintCloseAuthority, repeatByte(0x11, 32)))
+
+	t.Run("too short for base", func(t *testing.T) {
+		_, err := DecodeMintWithExtensions(testMintSlice[:50])
+		ag_require.ErrorIs(t, err, ErrInvalidAccountData)
+	})
+	t.Run("between base and TLV start", func(t *testing.T) {
+		_, err := DecodeMintWithExtensions(concat(testMintSlice, repeatByte(0, 18)))
+		ag_require.ErrorIs(t, err, ErrInvalidAccountData)
+	})
+	t.Run("multisig length rejected", func(t *testing.T) {
+		data := concat(valid, repeatByte(0, multisigSize-len(valid)))
+		ag_require.Equal(t, multisigSize, len(data))
+		_, err := DecodeMintWithExtensions(data)
+		ag_require.ErrorIs(t, err, ErrInvalidAccountData)
+	})
+	t.Run("nonzero padding", func(t *testing.T) {
+		data := append([]byte(nil), valid...)
+		data[100] = 1
+		_, err := DecodeMintWithExtensions(data)
+		ag_require.ErrorIs(t, err, ErrInvalidAccountData)
+	})
+	t.Run("wrong account type byte", func(t *testing.T) {
+		data := append([]byte(nil), valid...)
+		data[ACCOUNT_SIZE] = AccountTypeAccount
+		_, err := DecodeMintWithExtensions(data)
+		ag_require.ErrorIs(t, err, ErrInvalidAccountData)
+	})
+	t.Run("account extension on mint", func(t *testing.T) {
+		data := extendedMintData(tlvEntry(ExtensionTransferFeeAmount, u64LE(1)))
+		_, err := DecodeMintWithExtensions(data)
+		ag_require.ErrorIs(t, err, ErrExtensionTypeMismatch)
+	})
+	t.Run("mint extension on account", func(t *testing.T) {
+		data := extendedAccountData(tlvEntry(ExtensionMintCloseAuthority, repeatByte(0x11, 32)))
+		_, err := DecodeAccountWithExtensions(data)
+		ag_require.ErrorIs(t, err, ErrExtensionTypeMismatch)
+	})
+	t.Run("duplicate extension", func(t *testing.T) {
+		data := extendedMintData(
+			tlvEntry(ExtensionMintCloseAuthority, repeatByte(0x11, 32)),
+			tlvEntry(ExtensionMintCloseAuthority, repeatByte(0x22, 32)),
+		)
+		_, err := DecodeMintWithExtensions(data)
+		ag_require.ErrorIs(t, err, ErrDuplicateExtension)
+	})
+	t.Run("wrong extension length", func(t *testing.T) {
+		data := extendedMintData(tlvEntry(ExtensionMintCloseAuthority, repeatByte(0x11, 31)))
+		_, err := DecodeMintWithExtensions(data)
+		ag_require.ErrorIs(t, err, ErrInvalidExtensionLength)
+	})
+	t.Run("marker with nonzero length", func(t *testing.T) {
+		data := extendedMintData(tlvEntry(ExtensionNonTransferable, []byte{1}))
+		_, err := DecodeMintWithExtensions(data)
+		ag_require.ErrorIs(t, err, ErrInvalidExtensionLength)
+	})
+	t.Run("valid baseline decodes", func(t *testing.T) {
+		m, err := DecodeMintWithExtensions(valid)
+		ag_require.NoError(t, err)
+		ag_require.NotNil(t, m.MintCloseAuthority)
+		ag_require.Equal(t, pubkeyOf(0x11), m.MintCloseAuthority.CloseAuthority.Key)
+	})
+}
+
+func TestMarshalBinary_HandBuiltMint_MultisigBump(t *testing.T) {
+	// Hand-built mints encode extensions in ascending type order:
+	// MetadataPointer(18), TokenGroup(21), Pausable(26).
+	// 166 + (4+64) + (4+80) + (4+33) = 355, which collides with the multisig
+	// length and must be padded to 357.
+	groupAuthority := pubkeyOf(0x51)
+	pauseAuthority := pubkeyOf(0x52)
+	ptrAuthority := pubkeyOf(0x53)
+
+	m := &MintWithExtensions{
+		Mint: Mint{Supply: 9, Decimals: 6, IsInitialized: true},
+		TokenGroup: &TokenGroup{
+			UpdateAuthority: NewOptionalPubkey(&groupAuthority),
+			Mint:            pubkeyOf(0x54),
+			Size:            7,
+			MaxSize:         1 << 40,
+		},
+		Pausable: &PausableState{Authority: NewOptionalPubkey(&pauseAuthority), Paused: true},
+		MetadataPointer: &MetadataPointerState{
+			Authority:       NewOptionalPubkey(&ptrAuthority),
+			MetadataAddress: NewOptionalPubkey(&ptrAuthority),
+		},
+	}
+
+	want, err := CalculateMintLen([]ExtensionType{ExtensionTokenGroup, ExtensionPausable, ExtensionMetadataPointer})
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, 357, want)
+
+	out, err := m.MarshalBinary()
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, want, len(out))
+	ag_require.Equal(t, []byte{0, 0}, out[355:])
+
+	// Extensions appear in ascending type order.
+	ag_require.Equal(t, u16LE(uint16(ExtensionMetadataPointer)), out[166:168])
+	ag_require.Equal(t, u16LE(uint16(ExtensionTokenGroup)), out[234:236])
+	ag_require.Equal(t, u16LE(uint16(ExtensionPausable)), out[318:320])
+
+	// The trailing zero bytes decode as a terminator, so the data round-trips.
+	m2, err := DecodeMintWithExtensions(out)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, m.Mint, m2.Mint)
+	ag_require.Equal(t, m.TokenGroup, m2.TokenGroup)
+	ag_require.Equal(t, m.Pausable, m2.Pausable)
+	ag_require.Equal(t, m.MetadataPointer, m2.MetadataPointer)
+}
+
+func TestMarshalBinary_ClearedExtensionIsSkipped(t *testing.T) {
+	data := extendedAccountData(
+		tlvEntry(ExtensionCpiGuard, []byte{1}),
+		tlvEntry(ExtensionTransferFeeAmount, u64LE(42)),
+	)
+	a, err := DecodeAccountWithExtensions(data)
+	ag_require.NoError(t, err)
+
+	a.CpiGuard = nil
+	out, err := a.MarshalBinary()
+	ag_require.NoError(t, err)
+
+	a2, err := DecodeAccountWithExtensions(out)
+	ag_require.NoError(t, err)
+	ag_require.Nil(t, a2.CpiGuard)
+	ag_require.NotNil(t, a2.TransferFeeAmount)
+	ag_require.Equal(t, uint64(42), a2.TransferFeeAmount.WithheldAmount)
+}
+
+func TestMarshalBinary_EditedUnknownStaysConsistent(t *testing.T) {
+	// Regression: unknown entries are re-encoded with their own type+data
+	// pair. Removing one from Unknown after decode must not shift another
+	// entry's data under the removed entry's type.
+	data := extendedMintData(
+		tlvEntry(ExtensionType(999), []byte{9, 9, 9}),
+		tlvEntry(ExtensionType(998), []byte{8, 8}),
+	)
+	m, err := DecodeMintWithExtensions(data)
+	ag_require.NoError(t, err)
+	ag_require.Len(t, m.Unknown, 2)
+
+	m.Unknown = m.Unknown[1:] // drop the 999 entry
+	out, err := m.MarshalBinary()
+	ag_require.NoError(t, err)
+
+	want := extendedMintData(tlvEntry(ExtensionType(998), []byte{8, 8}))
+	ag_require.Equal(t, want, out)
+}
+
+func TestParseExtensions_DataAppendDoesNotClobber(t *testing.T) {
+	// Regression: ExtensionTLV.Data capacity is capped, so appending to one
+	// entry's Data must allocate instead of overwriting the next entry.
+	buf := concat(
+		tlvEntry(ExtensionCpiGuard, []byte{1}),
+		tlvEntry(ExtensionMemoTransfer, []byte{1}),
+	)
+	tlvs, err := ParseExtensions(buf)
+	ag_require.NoError(t, err)
+	ag_require.Len(t, tlvs, 2)
+
+	_ = append(tlvs[0].Data, 0xFF, 0xFF, 0xFF)
+	ag_require.Equal(t, []byte{1}, tlvs[1].Data)
+	ag_require.Equal(t, concat(
+		tlvEntry(ExtensionCpiGuard, []byte{1}),
+		tlvEntry(ExtensionMemoTransfer, []byte{1}),
+	), buf)
+}
+
+func TestMarshalBinary_AddedExtensionAppended(t *testing.T) {
+	data := extendedAccountData(tlvEntry(ExtensionCpiGuard, []byte{1}))
+	a, err := DecodeAccountWithExtensions(data)
+	ag_require.NoError(t, err)
+
+	// Adding a lower-numbered extension after decode appends it after the
+	// original entries rather than reordering them.
+	a.TransferFeeAmount = &TransferFeeAmountState{WithheldAmount: 5}
+	out, err := a.MarshalBinary()
+	ag_require.NoError(t, err)
+
+	wantPrefix := extendedAccountData(
+		tlvEntry(ExtensionCpiGuard, []byte{1}),
+		tlvEntry(ExtensionTransferFeeAmount, u64LE(5)),
+	)
+	ag_require.Equal(t, wantPrefix, out)
+}

--- a/programs/token-2022/extension_codecs.go
+++ b/programs/token-2022/extension_codecs.go
@@ -1,0 +1,716 @@
+package token2022
+
+import (
+	"fmt"
+
+	bin "github.com/gagliardetto/binary"
+	"github.com/gagliardetto/solana-go"
+)
+
+// This file implements byte-exact codecs for the fixed-size token-2022
+// extension states, mirroring the Pod layouts of the Rust
+// spl-token-2022-interface crate: all fields are little-endian with align 1,
+// so structs serialize as the plain concatenation of their fields.
+//
+// Booleans follow PodBool semantics: any nonzero byte decodes as true, and
+// true encodes as 1. Optional pubkeys are raw 32 bytes where all zeros means
+// None (no tag byte).
+
+func (o *OptionalPubkey) UnmarshalWithDecoder(dec *bin.Decoder) error {
+	v, err := dec.ReadNBytes(32)
+	if err != nil {
+		return err
+	}
+	o.Key = solana.PublicKeyFromBytes(v)
+	return nil
+}
+
+func (o OptionalPubkey) MarshalWithEncoder(enc *bin.Encoder) error {
+	return enc.WriteBytes(o.Key[:], false)
+}
+
+// readFixedBytes fills dst from the decoder.
+func readFixedBytes(dec *bin.Decoder, dst []byte) error {
+	v, err := dec.ReadNBytes(len(dst))
+	if err != nil {
+		return err
+	}
+	copy(dst, v)
+	return nil
+}
+
+// decodeFixedState decodes an extension state with a fixed wire size,
+// rejecting data of any other length.
+func decodeFixedState[T any, PT interface {
+	*T
+	bin.BinaryUnmarshaler
+}](data []byte, want int, name string) (*T, error) {
+	if len(data) != want {
+		return nil, fmt.Errorf("%w: %s requires %d bytes, got %d", ErrInvalidExtensionLength, name, want, len(data))
+	}
+	out := PT(new(T))
+	if err := out.UnmarshalWithDecoder(bin.NewBinDecoder(data)); err != nil {
+		return nil, fmt.Errorf("unable to decode %s: %w", name, err)
+	}
+	return out, nil
+}
+
+// --- TransferFee ---
+
+func (f *TransferFee) UnmarshalWithDecoder(dec *bin.Decoder) error {
+	var err error
+	if f.Epoch, err = dec.ReadUint64(bin.LE); err != nil {
+		return err
+	}
+	if f.MaximumFee, err = dec.ReadUint64(bin.LE); err != nil {
+		return err
+	}
+	if f.TransferFeeBasisPoints, err = dec.ReadUint16(bin.LE); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (f TransferFee) MarshalWithEncoder(enc *bin.Encoder) error {
+	if err := enc.WriteUint64(f.Epoch, bin.LE); err != nil {
+		return err
+	}
+	if err := enc.WriteUint64(f.MaximumFee, bin.LE); err != nil {
+		return err
+	}
+	return enc.WriteUint16(f.TransferFeeBasisPoints, bin.LE)
+}
+
+// --- TransferFeeConfigState (108 bytes) ---
+
+func (s *TransferFeeConfigState) UnmarshalWithDecoder(dec *bin.Decoder) error {
+	if err := s.TransferFeeConfigAuthority.UnmarshalWithDecoder(dec); err != nil {
+		return err
+	}
+	if err := s.WithdrawWithheldAuthority.UnmarshalWithDecoder(dec); err != nil {
+		return err
+	}
+	var err error
+	if s.WithheldAmount, err = dec.ReadUint64(bin.LE); err != nil {
+		return err
+	}
+	if err := s.OlderTransferFee.UnmarshalWithDecoder(dec); err != nil {
+		return err
+	}
+	return s.NewerTransferFee.UnmarshalWithDecoder(dec)
+}
+
+func (s TransferFeeConfigState) MarshalWithEncoder(enc *bin.Encoder) error {
+	if err := s.TransferFeeConfigAuthority.MarshalWithEncoder(enc); err != nil {
+		return err
+	}
+	if err := s.WithdrawWithheldAuthority.MarshalWithEncoder(enc); err != nil {
+		return err
+	}
+	if err := enc.WriteUint64(s.WithheldAmount, bin.LE); err != nil {
+		return err
+	}
+	if err := s.OlderTransferFee.MarshalWithEncoder(enc); err != nil {
+		return err
+	}
+	return s.NewerTransferFee.MarshalWithEncoder(enc)
+}
+
+// DecodeTransferFeeConfigState decodes a TransferFeeConfigState from extension data.
+func DecodeTransferFeeConfigState(data []byte) (*TransferFeeConfigState, error) {
+	return decodeFixedState[TransferFeeConfigState](data, 108, "TransferFeeConfig")
+}
+
+// --- TransferFeeAmountState (8 bytes) ---
+
+func (s *TransferFeeAmountState) UnmarshalWithDecoder(dec *bin.Decoder) error {
+	var err error
+	s.WithheldAmount, err = dec.ReadUint64(bin.LE)
+	return err
+}
+
+func (s TransferFeeAmountState) MarshalWithEncoder(enc *bin.Encoder) error {
+	return enc.WriteUint64(s.WithheldAmount, bin.LE)
+}
+
+// DecodeTransferFeeAmountState decodes a TransferFeeAmountState from extension data.
+func DecodeTransferFeeAmountState(data []byte) (*TransferFeeAmountState, error) {
+	return decodeFixedState[TransferFeeAmountState](data, 8, "TransferFeeAmount")
+}
+
+// --- MintCloseAuthorityState (32 bytes) ---
+
+func (s *MintCloseAuthorityState) UnmarshalWithDecoder(dec *bin.Decoder) error {
+	return s.CloseAuthority.UnmarshalWithDecoder(dec)
+}
+
+func (s MintCloseAuthorityState) MarshalWithEncoder(enc *bin.Encoder) error {
+	return s.CloseAuthority.MarshalWithEncoder(enc)
+}
+
+// DecodeMintCloseAuthorityState decodes a MintCloseAuthorityState from extension data.
+func DecodeMintCloseAuthorityState(data []byte) (*MintCloseAuthorityState, error) {
+	return decodeFixedState[MintCloseAuthorityState](data, 32, "MintCloseAuthority")
+}
+
+// --- ConfidentialTransferMintState (65 bytes) ---
+
+func (s *ConfidentialTransferMintState) UnmarshalWithDecoder(dec *bin.Decoder) error {
+	if err := s.Authority.UnmarshalWithDecoder(dec); err != nil {
+		return err
+	}
+	var err error
+	if s.AutoApproveNewAccounts, err = dec.ReadBool(); err != nil {
+		return err
+	}
+	return readFixedBytes(dec, s.AuditorElGamalPubkey[:])
+}
+
+func (s ConfidentialTransferMintState) MarshalWithEncoder(enc *bin.Encoder) error {
+	if err := s.Authority.MarshalWithEncoder(enc); err != nil {
+		return err
+	}
+	if err := enc.WriteBool(s.AutoApproveNewAccounts); err != nil {
+		return err
+	}
+	return enc.WriteBytes(s.AuditorElGamalPubkey[:], false)
+}
+
+// DecodeConfidentialTransferMintState decodes a ConfidentialTransferMintState from extension data.
+func DecodeConfidentialTransferMintState(data []byte) (*ConfidentialTransferMintState, error) {
+	return decodeFixedState[ConfidentialTransferMintState](data, 65, "ConfidentialTransferMint")
+}
+
+// --- ConfidentialTransferAccountState (295 bytes) ---
+
+func (s *ConfidentialTransferAccountState) UnmarshalWithDecoder(dec *bin.Decoder) error {
+	var err error
+	if s.Approved, err = dec.ReadBool(); err != nil {
+		return err
+	}
+	if err = readFixedBytes(dec, s.ElGamalPubkey[:]); err != nil {
+		return err
+	}
+	if err = readFixedBytes(dec, s.PendingBalanceLo[:]); err != nil {
+		return err
+	}
+	if err = readFixedBytes(dec, s.PendingBalanceHi[:]); err != nil {
+		return err
+	}
+	if err = readFixedBytes(dec, s.AvailableBalance[:]); err != nil {
+		return err
+	}
+	if err = readFixedBytes(dec, s.DecryptableAvailableBalance[:]); err != nil {
+		return err
+	}
+	if s.AllowConfidentialCredits, err = dec.ReadBool(); err != nil {
+		return err
+	}
+	if s.AllowNonConfidentialCredits, err = dec.ReadBool(); err != nil {
+		return err
+	}
+	if s.PendingBalanceCreditCounter, err = dec.ReadUint64(bin.LE); err != nil {
+		return err
+	}
+	if s.MaximumPendingBalanceCreditCounter, err = dec.ReadUint64(bin.LE); err != nil {
+		return err
+	}
+	if s.ExpectedPendingBalanceCreditCounter, err = dec.ReadUint64(bin.LE); err != nil {
+		return err
+	}
+	s.ActualPendingBalanceCreditCounter, err = dec.ReadUint64(bin.LE)
+	return err
+}
+
+func (s ConfidentialTransferAccountState) MarshalWithEncoder(enc *bin.Encoder) error {
+	if err := enc.WriteBool(s.Approved); err != nil {
+		return err
+	}
+	if err := enc.WriteBytes(s.ElGamalPubkey[:], false); err != nil {
+		return err
+	}
+	if err := enc.WriteBytes(s.PendingBalanceLo[:], false); err != nil {
+		return err
+	}
+	if err := enc.WriteBytes(s.PendingBalanceHi[:], false); err != nil {
+		return err
+	}
+	if err := enc.WriteBytes(s.AvailableBalance[:], false); err != nil {
+		return err
+	}
+	if err := enc.WriteBytes(s.DecryptableAvailableBalance[:], false); err != nil {
+		return err
+	}
+	if err := enc.WriteBool(s.AllowConfidentialCredits); err != nil {
+		return err
+	}
+	if err := enc.WriteBool(s.AllowNonConfidentialCredits); err != nil {
+		return err
+	}
+	if err := enc.WriteUint64(s.PendingBalanceCreditCounter, bin.LE); err != nil {
+		return err
+	}
+	if err := enc.WriteUint64(s.MaximumPendingBalanceCreditCounter, bin.LE); err != nil {
+		return err
+	}
+	if err := enc.WriteUint64(s.ExpectedPendingBalanceCreditCounter, bin.LE); err != nil {
+		return err
+	}
+	return enc.WriteUint64(s.ActualPendingBalanceCreditCounter, bin.LE)
+}
+
+// DecodeConfidentialTransferAccountState decodes a ConfidentialTransferAccountState from extension data.
+func DecodeConfidentialTransferAccountState(data []byte) (*ConfidentialTransferAccountState, error) {
+	return decodeFixedState[ConfidentialTransferAccountState](data, 295, "ConfidentialTransferAccount")
+}
+
+// --- DefaultAccountStateConfig (1 byte) ---
+
+func (s *DefaultAccountStateConfig) UnmarshalWithDecoder(dec *bin.Decoder) error {
+	v, err := dec.ReadUint8()
+	if err != nil {
+		return err
+	}
+	s.State = AccountState(v)
+	return nil
+}
+
+func (s DefaultAccountStateConfig) MarshalWithEncoder(enc *bin.Encoder) error {
+	return enc.WriteUint8(uint8(s.State))
+}
+
+// DecodeDefaultAccountStateConfig decodes a DefaultAccountStateConfig from extension data.
+func DecodeDefaultAccountStateConfig(data []byte) (*DefaultAccountStateConfig, error) {
+	return decodeFixedState[DefaultAccountStateConfig](data, 1, "DefaultAccountState")
+}
+
+// --- MemoTransferState (1 byte) ---
+
+func (s *MemoTransferState) UnmarshalWithDecoder(dec *bin.Decoder) error {
+	var err error
+	s.RequireIncomingTransferMemos, err = dec.ReadBool()
+	return err
+}
+
+func (s MemoTransferState) MarshalWithEncoder(enc *bin.Encoder) error {
+	return enc.WriteBool(s.RequireIncomingTransferMemos)
+}
+
+// DecodeMemoTransferState decodes a MemoTransferState from extension data.
+func DecodeMemoTransferState(data []byte) (*MemoTransferState, error) {
+	return decodeFixedState[MemoTransferState](data, 1, "MemoTransfer")
+}
+
+// --- InterestBearingConfigState (52 bytes) ---
+// Note the interleaved field order: authority, i64 timestamp, i16 rate,
+// i64 timestamp, i16 rate. This matches the on-chain layout exactly.
+
+func (s *InterestBearingConfigState) UnmarshalWithDecoder(dec *bin.Decoder) error {
+	if err := s.RateAuthority.UnmarshalWithDecoder(dec); err != nil {
+		return err
+	}
+	var err error
+	if s.InitializationTimestamp, err = dec.ReadInt64(bin.LE); err != nil {
+		return err
+	}
+	if s.PreUpdateAverageRate, err = dec.ReadInt16(bin.LE); err != nil {
+		return err
+	}
+	if s.LastUpdateTimestamp, err = dec.ReadInt64(bin.LE); err != nil {
+		return err
+	}
+	s.CurrentRate, err = dec.ReadInt16(bin.LE)
+	return err
+}
+
+func (s InterestBearingConfigState) MarshalWithEncoder(enc *bin.Encoder) error {
+	if err := s.RateAuthority.MarshalWithEncoder(enc); err != nil {
+		return err
+	}
+	if err := enc.WriteInt64(s.InitializationTimestamp, bin.LE); err != nil {
+		return err
+	}
+	if err := enc.WriteInt16(s.PreUpdateAverageRate, bin.LE); err != nil {
+		return err
+	}
+	if err := enc.WriteInt64(s.LastUpdateTimestamp, bin.LE); err != nil {
+		return err
+	}
+	return enc.WriteInt16(s.CurrentRate, bin.LE)
+}
+
+// DecodeInterestBearingConfigState decodes an InterestBearingConfigState from extension data.
+func DecodeInterestBearingConfigState(data []byte) (*InterestBearingConfigState, error) {
+	return decodeFixedState[InterestBearingConfigState](data, 52, "InterestBearingConfig")
+}
+
+// --- CpiGuardState (1 byte) ---
+
+func (s *CpiGuardState) UnmarshalWithDecoder(dec *bin.Decoder) error {
+	var err error
+	s.LockCpi, err = dec.ReadBool()
+	return err
+}
+
+func (s CpiGuardState) MarshalWithEncoder(enc *bin.Encoder) error {
+	return enc.WriteBool(s.LockCpi)
+}
+
+// DecodeCpiGuardState decodes a CpiGuardState from extension data.
+func DecodeCpiGuardState(data []byte) (*CpiGuardState, error) {
+	return decodeFixedState[CpiGuardState](data, 1, "CpiGuard")
+}
+
+// --- PermanentDelegateState (32 bytes) ---
+
+func (s *PermanentDelegateState) UnmarshalWithDecoder(dec *bin.Decoder) error {
+	return s.Delegate.UnmarshalWithDecoder(dec)
+}
+
+func (s PermanentDelegateState) MarshalWithEncoder(enc *bin.Encoder) error {
+	return s.Delegate.MarshalWithEncoder(enc)
+}
+
+// DecodePermanentDelegateState decodes a PermanentDelegateState from extension data.
+func DecodePermanentDelegateState(data []byte) (*PermanentDelegateState, error) {
+	return decodeFixedState[PermanentDelegateState](data, 32, "PermanentDelegate")
+}
+
+// --- TransferHookState (64 bytes) ---
+
+func (s *TransferHookState) UnmarshalWithDecoder(dec *bin.Decoder) error {
+	if err := s.Authority.UnmarshalWithDecoder(dec); err != nil {
+		return err
+	}
+	return s.ProgramID.UnmarshalWithDecoder(dec)
+}
+
+func (s TransferHookState) MarshalWithEncoder(enc *bin.Encoder) error {
+	if err := s.Authority.MarshalWithEncoder(enc); err != nil {
+		return err
+	}
+	return s.ProgramID.MarshalWithEncoder(enc)
+}
+
+// DecodeTransferHookState decodes a TransferHookState from extension data.
+func DecodeTransferHookState(data []byte) (*TransferHookState, error) {
+	return decodeFixedState[TransferHookState](data, 64, "TransferHook")
+}
+
+// --- TransferHookAccountState (1 byte) ---
+
+func (s *TransferHookAccountState) UnmarshalWithDecoder(dec *bin.Decoder) error {
+	var err error
+	s.Transferring, err = dec.ReadBool()
+	return err
+}
+
+func (s TransferHookAccountState) MarshalWithEncoder(enc *bin.Encoder) error {
+	return enc.WriteBool(s.Transferring)
+}
+
+// DecodeTransferHookAccountState decodes a TransferHookAccountState from extension data.
+func DecodeTransferHookAccountState(data []byte) (*TransferHookAccountState, error) {
+	return decodeFixedState[TransferHookAccountState](data, 1, "TransferHookAccount")
+}
+
+// --- ConfidentialTransferFeeConfigState (129 bytes) ---
+
+func (s *ConfidentialTransferFeeConfigState) UnmarshalWithDecoder(dec *bin.Decoder) error {
+	if err := s.Authority.UnmarshalWithDecoder(dec); err != nil {
+		return err
+	}
+	if err := readFixedBytes(dec, s.WithdrawWithheldAuthorityElGamalPubkey[:]); err != nil {
+		return err
+	}
+	var err error
+	if s.HarvestToMintEnabled, err = dec.ReadBool(); err != nil {
+		return err
+	}
+	return readFixedBytes(dec, s.WithheldAmount[:])
+}
+
+func (s ConfidentialTransferFeeConfigState) MarshalWithEncoder(enc *bin.Encoder) error {
+	if err := s.Authority.MarshalWithEncoder(enc); err != nil {
+		return err
+	}
+	if err := enc.WriteBytes(s.WithdrawWithheldAuthorityElGamalPubkey[:], false); err != nil {
+		return err
+	}
+	if err := enc.WriteBool(s.HarvestToMintEnabled); err != nil {
+		return err
+	}
+	return enc.WriteBytes(s.WithheldAmount[:], false)
+}
+
+// DecodeConfidentialTransferFeeConfigState decodes a ConfidentialTransferFeeConfigState from extension data.
+func DecodeConfidentialTransferFeeConfigState(data []byte) (*ConfidentialTransferFeeConfigState, error) {
+	return decodeFixedState[ConfidentialTransferFeeConfigState](data, 129, "ConfidentialTransferFeeConfig")
+}
+
+// --- ConfidentialTransferFeeAmountState (64 bytes) ---
+
+func (s *ConfidentialTransferFeeAmountState) UnmarshalWithDecoder(dec *bin.Decoder) error {
+	return readFixedBytes(dec, s.WithheldAmount[:])
+}
+
+func (s ConfidentialTransferFeeAmountState) MarshalWithEncoder(enc *bin.Encoder) error {
+	return enc.WriteBytes(s.WithheldAmount[:], false)
+}
+
+// DecodeConfidentialTransferFeeAmountState decodes a ConfidentialTransferFeeAmountState from extension data.
+func DecodeConfidentialTransferFeeAmountState(data []byte) (*ConfidentialTransferFeeAmountState, error) {
+	return decodeFixedState[ConfidentialTransferFeeAmountState](data, 64, "ConfidentialTransferFeeAmount")
+}
+
+// --- MetadataPointerState (64 bytes) ---
+
+func (s *MetadataPointerState) UnmarshalWithDecoder(dec *bin.Decoder) error {
+	if err := s.Authority.UnmarshalWithDecoder(dec); err != nil {
+		return err
+	}
+	return s.MetadataAddress.UnmarshalWithDecoder(dec)
+}
+
+func (s MetadataPointerState) MarshalWithEncoder(enc *bin.Encoder) error {
+	if err := s.Authority.MarshalWithEncoder(enc); err != nil {
+		return err
+	}
+	return s.MetadataAddress.MarshalWithEncoder(enc)
+}
+
+// DecodeMetadataPointerState decodes a MetadataPointerState from extension data.
+func DecodeMetadataPointerState(data []byte) (*MetadataPointerState, error) {
+	return decodeFixedState[MetadataPointerState](data, 64, "MetadataPointer")
+}
+
+// --- TokenMetadataState (variable length) ---
+
+// DecodeTokenMetadataState decodes a TokenMetadataState from extension data,
+// requiring that all bytes are consumed.
+func DecodeTokenMetadataState(data []byte) (*TokenMetadataState, error) {
+	out := new(TokenMetadataState)
+	dec := bin.NewBinDecoder(data)
+	if err := out.UnmarshalWithDecoder(dec); err != nil {
+		return nil, fmt.Errorf("unable to decode TokenMetadata: %w", err)
+	}
+	if dec.Remaining() != 0 {
+		return nil, fmt.Errorf("%w: TokenMetadata has %d trailing bytes", ErrInvalidExtensionLength, dec.Remaining())
+	}
+	return out, nil
+}
+
+// --- GroupPointerState (64 bytes) ---
+
+func (s *GroupPointerState) UnmarshalWithDecoder(dec *bin.Decoder) error {
+	if err := s.Authority.UnmarshalWithDecoder(dec); err != nil {
+		return err
+	}
+	return s.GroupAddress.UnmarshalWithDecoder(dec)
+}
+
+func (s GroupPointerState) MarshalWithEncoder(enc *bin.Encoder) error {
+	if err := s.Authority.MarshalWithEncoder(enc); err != nil {
+		return err
+	}
+	return s.GroupAddress.MarshalWithEncoder(enc)
+}
+
+// DecodeGroupPointerState decodes a GroupPointerState from extension data.
+func DecodeGroupPointerState(data []byte) (*GroupPointerState, error) {
+	return decodeFixedState[GroupPointerState](data, 64, "GroupPointer")
+}
+
+// --- TokenGroup (80 bytes) ---
+
+func (s *TokenGroup) UnmarshalWithDecoder(dec *bin.Decoder) error {
+	if err := s.UpdateAuthority.UnmarshalWithDecoder(dec); err != nil {
+		return err
+	}
+	v, err := dec.ReadNBytes(32)
+	if err != nil {
+		return err
+	}
+	s.Mint = solana.PublicKeyFromBytes(v)
+	if s.Size, err = dec.ReadUint64(bin.LE); err != nil {
+		return err
+	}
+	s.MaxSize, err = dec.ReadUint64(bin.LE)
+	return err
+}
+
+func (s TokenGroup) MarshalWithEncoder(enc *bin.Encoder) error {
+	if err := s.UpdateAuthority.MarshalWithEncoder(enc); err != nil {
+		return err
+	}
+	if err := enc.WriteBytes(s.Mint[:], false); err != nil {
+		return err
+	}
+	if err := enc.WriteUint64(s.Size, bin.LE); err != nil {
+		return err
+	}
+	return enc.WriteUint64(s.MaxSize, bin.LE)
+}
+
+// DecodeTokenGroup decodes a TokenGroup from extension data.
+func DecodeTokenGroup(data []byte) (*TokenGroup, error) {
+	return decodeFixedState[TokenGroup](data, 80, "TokenGroup")
+}
+
+// --- GroupMemberPointerState (64 bytes) ---
+
+func (s *GroupMemberPointerState) UnmarshalWithDecoder(dec *bin.Decoder) error {
+	if err := s.Authority.UnmarshalWithDecoder(dec); err != nil {
+		return err
+	}
+	return s.MemberAddress.UnmarshalWithDecoder(dec)
+}
+
+func (s GroupMemberPointerState) MarshalWithEncoder(enc *bin.Encoder) error {
+	if err := s.Authority.MarshalWithEncoder(enc); err != nil {
+		return err
+	}
+	return s.MemberAddress.MarshalWithEncoder(enc)
+}
+
+// DecodeGroupMemberPointerState decodes a GroupMemberPointerState from extension data.
+func DecodeGroupMemberPointerState(data []byte) (*GroupMemberPointerState, error) {
+	return decodeFixedState[GroupMemberPointerState](data, 64, "GroupMemberPointer")
+}
+
+// --- TokenGroupMember (72 bytes) ---
+
+func (s *TokenGroupMember) UnmarshalWithDecoder(dec *bin.Decoder) error {
+	v, err := dec.ReadNBytes(32)
+	if err != nil {
+		return err
+	}
+	s.Mint = solana.PublicKeyFromBytes(v)
+	if v, err = dec.ReadNBytes(32); err != nil {
+		return err
+	}
+	s.Group = solana.PublicKeyFromBytes(v)
+	s.MemberNumber, err = dec.ReadUint64(bin.LE)
+	return err
+}
+
+func (s TokenGroupMember) MarshalWithEncoder(enc *bin.Encoder) error {
+	if err := enc.WriteBytes(s.Mint[:], false); err != nil {
+		return err
+	}
+	if err := enc.WriteBytes(s.Group[:], false); err != nil {
+		return err
+	}
+	return enc.WriteUint64(s.MemberNumber, bin.LE)
+}
+
+// DecodeTokenGroupMember decodes a TokenGroupMember from extension data.
+func DecodeTokenGroupMember(data []byte) (*TokenGroupMember, error) {
+	return decodeFixedState[TokenGroupMember](data, 72, "TokenGroupMember")
+}
+
+// --- ConfidentialMintBurnState (196 bytes) ---
+
+func (s *ConfidentialMintBurnState) UnmarshalWithDecoder(dec *bin.Decoder) error {
+	if err := readFixedBytes(dec, s.ConfidentialSupply[:]); err != nil {
+		return err
+	}
+	if err := readFixedBytes(dec, s.DecryptableSupply[:]); err != nil {
+		return err
+	}
+	if err := readFixedBytes(dec, s.SupplyElGamalPubkey[:]); err != nil {
+		return err
+	}
+	return readFixedBytes(dec, s.PendingBurn[:])
+}
+
+func (s ConfidentialMintBurnState) MarshalWithEncoder(enc *bin.Encoder) error {
+	if err := enc.WriteBytes(s.ConfidentialSupply[:], false); err != nil {
+		return err
+	}
+	if err := enc.WriteBytes(s.DecryptableSupply[:], false); err != nil {
+		return err
+	}
+	if err := enc.WriteBytes(s.SupplyElGamalPubkey[:], false); err != nil {
+		return err
+	}
+	return enc.WriteBytes(s.PendingBurn[:], false)
+}
+
+// DecodeConfidentialMintBurnState decodes a ConfidentialMintBurnState from extension data.
+func DecodeConfidentialMintBurnState(data []byte) (*ConfidentialMintBurnState, error) {
+	return decodeFixedState[ConfidentialMintBurnState](data, 196, "ConfidentialMintBurn")
+}
+
+// --- ScaledUiAmountState (56 bytes) ---
+
+func (s *ScaledUiAmountState) UnmarshalWithDecoder(dec *bin.Decoder) error {
+	if err := s.Authority.UnmarshalWithDecoder(dec); err != nil {
+		return err
+	}
+	var err error
+	if s.Multiplier, err = dec.ReadFloat64(bin.LE); err != nil {
+		return err
+	}
+	if s.NewMultiplierEffectiveTimestamp, err = dec.ReadInt64(bin.LE); err != nil {
+		return err
+	}
+	s.NewMultiplier, err = dec.ReadFloat64(bin.LE)
+	return err
+}
+
+func (s ScaledUiAmountState) MarshalWithEncoder(enc *bin.Encoder) error {
+	if err := s.Authority.MarshalWithEncoder(enc); err != nil {
+		return err
+	}
+	if err := enc.WriteFloat64(s.Multiplier, bin.LE); err != nil {
+		return err
+	}
+	if err := enc.WriteInt64(s.NewMultiplierEffectiveTimestamp, bin.LE); err != nil {
+		return err
+	}
+	return enc.WriteFloat64(s.NewMultiplier, bin.LE)
+}
+
+// DecodeScaledUiAmountState decodes a ScaledUiAmountState from extension data.
+func DecodeScaledUiAmountState(data []byte) (*ScaledUiAmountState, error) {
+	return decodeFixedState[ScaledUiAmountState](data, 56, "ScaledUiAmount")
+}
+
+// --- PausableState (33 bytes) ---
+
+func (s *PausableState) UnmarshalWithDecoder(dec *bin.Decoder) error {
+	if err := s.Authority.UnmarshalWithDecoder(dec); err != nil {
+		return err
+	}
+	var err error
+	s.Paused, err = dec.ReadBool()
+	return err
+}
+
+func (s PausableState) MarshalWithEncoder(enc *bin.Encoder) error {
+	if err := s.Authority.MarshalWithEncoder(enc); err != nil {
+		return err
+	}
+	return enc.WriteBool(s.Paused)
+}
+
+// DecodePausableState decodes a PausableState from extension data.
+func DecodePausableState(data []byte) (*PausableState, error) {
+	return decodeFixedState[PausableState](data, 33, "Pausable")
+}
+
+// --- PermissionedBurnState (32 bytes) ---
+
+func (s *PermissionedBurnState) UnmarshalWithDecoder(dec *bin.Decoder) error {
+	return s.Authority.UnmarshalWithDecoder(dec)
+}
+
+func (s PermissionedBurnState) MarshalWithEncoder(enc *bin.Encoder) error {
+	return s.Authority.MarshalWithEncoder(enc)
+}
+
+// DecodePermissionedBurnState decodes a PermissionedBurnState from extension data.
+func DecodePermissionedBurnState(data []byte) (*PermissionedBurnState, error) {
+	return decodeFixedState[PermissionedBurnState](data, 32, "PermissionedBurn")
+}

--- a/programs/token-2022/extension_codecs_test.go
+++ b/programs/token-2022/extension_codecs_test.go
@@ -1,0 +1,556 @@
+package token2022
+
+import (
+	"bytes"
+	"math"
+	"testing"
+
+	ag_binary "github.com/gagliardetto/binary"
+	ag_require "github.com/stretchr/testify/require"
+)
+
+func i64LE(v int64) []byte {
+	return u64LE(uint64(v))
+}
+
+func i16LE(v int16) []byte {
+	return u16LE(uint16(v))
+}
+
+func f64LE(v float64) []byte {
+	return u64LE(math.Float64bits(v))
+}
+
+func marshalStateBytes(t *testing.T, v ag_binary.BinaryMarshaler) []byte {
+	t.Helper()
+	buf := new(bytes.Buffer)
+	err := v.MarshalWithEncoder(ag_binary.NewBinEncoder(buf))
+	ag_require.NoError(t, err)
+	return buf.Bytes()
+}
+
+// TestRoundTrip_FixedSizeExtensionStates builds a byte fixture for every
+// fixed-size extension state at the exact offsets of the Rust
+// spl-token-2022-interface layout, decodes it, asserts every field, and
+// requires a byte-exact re-encode. It also checks that data one byte shorter
+// or longer is rejected.
+func TestRoundTrip_FixedSizeExtensionStates(t *testing.T) {
+	cases := []struct {
+		name    string
+		fixture []byte
+		decode  func([]byte) (ag_binary.BinaryMarshaler, error)
+		check   func(t *testing.T, got any)
+	}{
+		{
+			name: "TransferFeeConfig",
+			fixture: concat(
+				repeatByte(0x11, 32),             // transfer_fee_config_authority
+				repeatByte(0x22, 32),             // withdraw_withheld_authority
+				u64LE(0x1122334455667788),        // withheld_amount
+				u64LE(5), u64LE(1000), u16LE(50), // older_transfer_fee
+				u64LE(6), u64LE(2000), u16LE(75), // newer_transfer_fee
+			),
+			decode: func(d []byte) (ag_binary.BinaryMarshaler, error) { return DecodeTransferFeeConfigState(d) },
+			check: func(t *testing.T, got any) {
+				s := got.(*TransferFeeConfigState)
+				ag_require.Equal(t, pubkeyOf(0x11), s.TransferFeeConfigAuthority.Key)
+				ag_require.Equal(t, pubkeyOf(0x22), s.WithdrawWithheldAuthority.Key)
+				ag_require.Equal(t, uint64(0x1122334455667788), s.WithheldAmount)
+				ag_require.Equal(t, TransferFee{Epoch: 5, MaximumFee: 1000, TransferFeeBasisPoints: 50}, s.OlderTransferFee)
+				ag_require.Equal(t, TransferFee{Epoch: 6, MaximumFee: 2000, TransferFeeBasisPoints: 75}, s.NewerTransferFee)
+			},
+		},
+		{
+			name:    "TransferFeeAmount",
+			fixture: u64LE(0xAABBCCDDEEFF0011),
+			decode:  func(d []byte) (ag_binary.BinaryMarshaler, error) { return DecodeTransferFeeAmountState(d) },
+			check: func(t *testing.T, got any) {
+				ag_require.Equal(t, uint64(0xAABBCCDDEEFF0011), got.(*TransferFeeAmountState).WithheldAmount)
+			},
+		},
+		{
+			name:    "MintCloseAuthority",
+			fixture: repeatByte(0x33, 32),
+			decode:  func(d []byte) (ag_binary.BinaryMarshaler, error) { return DecodeMintCloseAuthorityState(d) },
+			check: func(t *testing.T, got any) {
+				ag_require.Equal(t, pubkeyOf(0x33), got.(*MintCloseAuthorityState).CloseAuthority.Key)
+			},
+		},
+		{
+			name: "ConfidentialTransferMint",
+			fixture: concat(
+				repeatByte(0x44, 32), // authority
+				[]byte{1},            // auto_approve_new_accounts
+				repeatByte(0x55, 32), // auditor_elgamal_pubkey
+			),
+			decode: func(d []byte) (ag_binary.BinaryMarshaler, error) { return DecodeConfidentialTransferMintState(d) },
+			check: func(t *testing.T, got any) {
+				s := got.(*ConfidentialTransferMintState)
+				ag_require.Equal(t, pubkeyOf(0x44), s.Authority.Key)
+				ag_require.True(t, s.AutoApproveNewAccounts)
+				ag_require.Equal(t, [32]byte(pubkeyOf(0x55)), s.AuditorElGamalPubkey)
+			},
+		},
+		{
+			name: "ConfidentialTransferAccount",
+			fixture: concat(
+				[]byte{1},                                  // approved
+				repeatByte(0x61, 32),                       // elgamal_pubkey
+				repeatByte(0x62, 64),                       // pending_balance_lo
+				repeatByte(0x63, 64),                       // pending_balance_hi
+				repeatByte(0x64, 64),                       // available_balance
+				repeatByte(0x65, 36),                       // decryptable_available_balance
+				[]byte{1},                                  // allow_confidential_credits
+				[]byte{0},                                  // allow_non_confidential_credits
+				u64LE(11), u64LE(12), u64LE(13), u64LE(14), // credit counters
+			),
+			decode: func(d []byte) (ag_binary.BinaryMarshaler, error) { return DecodeConfidentialTransferAccountState(d) },
+			check: func(t *testing.T, got any) {
+				s := got.(*ConfidentialTransferAccountState)
+				ag_require.True(t, s.Approved)
+				ag_require.Equal(t, [32]byte(pubkeyOf(0x61)), s.ElGamalPubkey)
+				ag_require.Equal(t, [64]byte(repeatByte(0x62, 64)), s.PendingBalanceLo)
+				ag_require.Equal(t, [64]byte(repeatByte(0x63, 64)), s.PendingBalanceHi)
+				ag_require.Equal(t, [64]byte(repeatByte(0x64, 64)), s.AvailableBalance)
+				ag_require.Equal(t, [36]byte(repeatByte(0x65, 36)), s.DecryptableAvailableBalance)
+				ag_require.True(t, s.AllowConfidentialCredits)
+				ag_require.False(t, s.AllowNonConfidentialCredits)
+				ag_require.Equal(t, uint64(11), s.PendingBalanceCreditCounter)
+				ag_require.Equal(t, uint64(12), s.MaximumPendingBalanceCreditCounter)
+				ag_require.Equal(t, uint64(13), s.ExpectedPendingBalanceCreditCounter)
+				ag_require.Equal(t, uint64(14), s.ActualPendingBalanceCreditCounter)
+			},
+		},
+		{
+			name:    "DefaultAccountState",
+			fixture: []byte{2},
+			decode:  func(d []byte) (ag_binary.BinaryMarshaler, error) { return DecodeDefaultAccountStateConfig(d) },
+			check: func(t *testing.T, got any) {
+				ag_require.Equal(t, AccountStateFrozen, got.(*DefaultAccountStateConfig).State)
+			},
+		},
+		{
+			name:    "MemoTransfer",
+			fixture: []byte{1},
+			decode:  func(d []byte) (ag_binary.BinaryMarshaler, error) { return DecodeMemoTransferState(d) },
+			check: func(t *testing.T, got any) {
+				ag_require.True(t, got.(*MemoTransferState).RequireIncomingTransferMemos)
+			},
+		},
+		{
+			name: "InterestBearingConfig",
+			fixture: concat(
+				repeatByte(0x77, 32), // rate_authority
+				i64LE(1700000001),    // initialization_timestamp
+				i16LE(-1234),         // pre_update_average_rate
+				i64LE(1700000002),    // last_update_timestamp
+				i16LE(567),           // current_rate
+			),
+			decode: func(d []byte) (ag_binary.BinaryMarshaler, error) { return DecodeInterestBearingConfigState(d) },
+			check: func(t *testing.T, got any) {
+				s := got.(*InterestBearingConfigState)
+				ag_require.Equal(t, pubkeyOf(0x77), s.RateAuthority.Key)
+				ag_require.Equal(t, int64(1700000001), s.InitializationTimestamp)
+				ag_require.Equal(t, int16(-1234), s.PreUpdateAverageRate)
+				ag_require.Equal(t, int64(1700000002), s.LastUpdateTimestamp)
+				ag_require.Equal(t, int16(567), s.CurrentRate)
+			},
+		},
+		{
+			name:    "CpiGuard",
+			fixture: []byte{1},
+			decode:  func(d []byte) (ag_binary.BinaryMarshaler, error) { return DecodeCpiGuardState(d) },
+			check: func(t *testing.T, got any) {
+				ag_require.True(t, got.(*CpiGuardState).LockCpi)
+			},
+		},
+		{
+			name:    "PermanentDelegate",
+			fixture: repeatByte(0x88, 32),
+			decode:  func(d []byte) (ag_binary.BinaryMarshaler, error) { return DecodePermanentDelegateState(d) },
+			check: func(t *testing.T, got any) {
+				ag_require.Equal(t, pubkeyOf(0x88), got.(*PermanentDelegateState).Delegate.Key)
+			},
+		},
+		{
+			name:    "TransferHook",
+			fixture: concat(repeatByte(0x91, 32), repeatByte(0x92, 32)),
+			decode:  func(d []byte) (ag_binary.BinaryMarshaler, error) { return DecodeTransferHookState(d) },
+			check: func(t *testing.T, got any) {
+				s := got.(*TransferHookState)
+				ag_require.Equal(t, pubkeyOf(0x91), s.Authority.Key)
+				ag_require.Equal(t, pubkeyOf(0x92), s.ProgramID.Key)
+			},
+		},
+		{
+			name:    "TransferHookAccount",
+			fixture: []byte{1},
+			decode:  func(d []byte) (ag_binary.BinaryMarshaler, error) { return DecodeTransferHookAccountState(d) },
+			check: func(t *testing.T, got any) {
+				ag_require.True(t, got.(*TransferHookAccountState).Transferring)
+			},
+		},
+		{
+			name: "ConfidentialTransferFeeConfig",
+			fixture: concat(
+				repeatByte(0xA1, 32), // authority
+				repeatByte(0xA2, 32), // withdraw_withheld_authority_elgamal_pubkey
+				[]byte{1},            // harvest_to_mint_enabled
+				repeatByte(0xA3, 64), // withheld_amount
+			),
+			decode: func(d []byte) (ag_binary.BinaryMarshaler, error) {
+				return DecodeConfidentialTransferFeeConfigState(d)
+			},
+			check: func(t *testing.T, got any) {
+				s := got.(*ConfidentialTransferFeeConfigState)
+				ag_require.Equal(t, pubkeyOf(0xA1), s.Authority.Key)
+				ag_require.Equal(t, [32]byte(pubkeyOf(0xA2)), s.WithdrawWithheldAuthorityElGamalPubkey)
+				ag_require.True(t, s.HarvestToMintEnabled)
+				ag_require.Equal(t, [64]byte(repeatByte(0xA3, 64)), s.WithheldAmount)
+			},
+		},
+		{
+			name:    "ConfidentialTransferFeeAmount",
+			fixture: repeatByte(0xB1, 64),
+			decode: func(d []byte) (ag_binary.BinaryMarshaler, error) {
+				return DecodeConfidentialTransferFeeAmountState(d)
+			},
+			check: func(t *testing.T, got any) {
+				ag_require.Equal(t, [64]byte(repeatByte(0xB1, 64)), got.(*ConfidentialTransferFeeAmountState).WithheldAmount)
+			},
+		},
+		{
+			name:    "MetadataPointer",
+			fixture: concat(repeatByte(0xC1, 32), repeatByte(0xC2, 32)),
+			decode:  func(d []byte) (ag_binary.BinaryMarshaler, error) { return DecodeMetadataPointerState(d) },
+			check: func(t *testing.T, got any) {
+				s := got.(*MetadataPointerState)
+				ag_require.Equal(t, pubkeyOf(0xC1), s.Authority.Key)
+				ag_require.Equal(t, pubkeyOf(0xC2), s.MetadataAddress.Key)
+			},
+		},
+		{
+			name:    "GroupPointer",
+			fixture: concat(repeatByte(0xC3, 32), repeatByte(0xC4, 32)),
+			decode:  func(d []byte) (ag_binary.BinaryMarshaler, error) { return DecodeGroupPointerState(d) },
+			check: func(t *testing.T, got any) {
+				s := got.(*GroupPointerState)
+				ag_require.Equal(t, pubkeyOf(0xC3), s.Authority.Key)
+				ag_require.Equal(t, pubkeyOf(0xC4), s.GroupAddress.Key)
+			},
+		},
+		{
+			name: "TokenGroup",
+			fixture: concat(
+				repeatByte(0xD1, 32),      // update_authority
+				repeatByte(0xD2, 32),      // mint
+				u64LE(0x1_0000_0001),      // size > MaxUint32: proves u64 width
+				u64LE(0xFFFF_FFFF_FFFF_0), // max_size
+			),
+			decode: func(d []byte) (ag_binary.BinaryMarshaler, error) { return DecodeTokenGroup(d) },
+			check: func(t *testing.T, got any) {
+				s := got.(*TokenGroup)
+				ag_require.Equal(t, pubkeyOf(0xD1), s.UpdateAuthority.Key)
+				ag_require.Equal(t, pubkeyOf(0xD2), s.Mint)
+				ag_require.Equal(t, uint64(0x1_0000_0001), s.Size)
+				ag_require.Equal(t, uint64(0xFFFF_FFFF_FFFF_0), s.MaxSize)
+			},
+		},
+		{
+			name:    "GroupMemberPointer",
+			fixture: concat(repeatByte(0xD3, 32), repeatByte(0xD4, 32)),
+			decode:  func(d []byte) (ag_binary.BinaryMarshaler, error) { return DecodeGroupMemberPointerState(d) },
+			check: func(t *testing.T, got any) {
+				s := got.(*GroupMemberPointerState)
+				ag_require.Equal(t, pubkeyOf(0xD3), s.Authority.Key)
+				ag_require.Equal(t, pubkeyOf(0xD4), s.MemberAddress.Key)
+			},
+		},
+		{
+			name: "TokenGroupMember",
+			fixture: concat(
+				repeatByte(0xD5, 32), // mint
+				repeatByte(0xD6, 32), // group
+				u64LE(0x2_0000_0007), // member_number > MaxUint32: proves u64 width
+			),
+			decode: func(d []byte) (ag_binary.BinaryMarshaler, error) { return DecodeTokenGroupMember(d) },
+			check: func(t *testing.T, got any) {
+				s := got.(*TokenGroupMember)
+				ag_require.Equal(t, pubkeyOf(0xD5), s.Mint)
+				ag_require.Equal(t, pubkeyOf(0xD6), s.Group)
+				ag_require.Equal(t, uint64(0x2_0000_0007), s.MemberNumber)
+			},
+		},
+		{
+			name: "ConfidentialMintBurn",
+			fixture: concat(
+				repeatByte(0xE1, 64), // confidential_supply
+				repeatByte(0xE2, 36), // decryptable_supply
+				repeatByte(0xE3, 32), // supply_elgamal_pubkey
+				repeatByte(0xE4, 64), // pending_burn
+			),
+			decode: func(d []byte) (ag_binary.BinaryMarshaler, error) { return DecodeConfidentialMintBurnState(d) },
+			check: func(t *testing.T, got any) {
+				s := got.(*ConfidentialMintBurnState)
+				ag_require.Equal(t, [64]byte(repeatByte(0xE1, 64)), s.ConfidentialSupply)
+				ag_require.Equal(t, [36]byte(repeatByte(0xE2, 36)), s.DecryptableSupply)
+				ag_require.Equal(t, [32]byte(pubkeyOf(0xE3)), s.SupplyElGamalPubkey)
+				ag_require.Equal(t, [64]byte(repeatByte(0xE4, 64)), s.PendingBurn)
+			},
+		},
+		{
+			name: "ScaledUiAmount",
+			fixture: concat(
+				repeatByte(0xF1, 32), // authority
+				f64LE(1.5),           // multiplier
+				i64LE(1750000000),    // new_multiplier_effective_timestamp
+				f64LE(2.25),          // new_multiplier
+			),
+			decode: func(d []byte) (ag_binary.BinaryMarshaler, error) { return DecodeScaledUiAmountState(d) },
+			check: func(t *testing.T, got any) {
+				s := got.(*ScaledUiAmountState)
+				ag_require.Equal(t, pubkeyOf(0xF1), s.Authority.Key)
+				ag_require.Equal(t, 1.5, s.Multiplier)
+				ag_require.Equal(t, int64(1750000000), s.NewMultiplierEffectiveTimestamp)
+				ag_require.Equal(t, 2.25, s.NewMultiplier)
+			},
+		},
+		{
+			name:    "Pausable",
+			fixture: concat(repeatByte(0xF2, 32), []byte{1}),
+			decode:  func(d []byte) (ag_binary.BinaryMarshaler, error) { return DecodePausableState(d) },
+			check: func(t *testing.T, got any) {
+				s := got.(*PausableState)
+				ag_require.Equal(t, pubkeyOf(0xF2), s.Authority.Key)
+				ag_require.True(t, s.Paused)
+			},
+		},
+		{
+			name:    "PermissionedBurn",
+			fixture: repeatByte(0xF3, 32),
+			decode:  func(d []byte) (ag_binary.BinaryMarshaler, error) { return DecodePermissionedBurnState(d) },
+			check: func(t *testing.T, got any) {
+				ag_require.Equal(t, pubkeyOf(0xF3), got.(*PermissionedBurnState).Authority.Key)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// The fixture length must agree with the extension type table.
+			var typeOf ExtensionType
+			found := false
+			for et, info := range extensionInfos {
+				if info.name == tc.name {
+					typeOf = et
+					found = true
+				}
+			}
+			ag_require.True(t, found, "case name %q not present in extensionInfos", tc.name)
+			n, sized := typeOf.TypeLen()
+			ag_require.True(t, sized)
+			ag_require.Equal(t, n, len(tc.fixture), "extensionInfos length disagrees with fixture")
+
+			got, err := tc.decode(tc.fixture)
+			ag_require.NoError(t, err)
+			tc.check(t, got)
+
+			// Byte-exact re-encode.
+			ag_require.Equal(t, tc.fixture, marshalStateBytes(t, got))
+
+			// Wrong lengths are rejected.
+			_, err = tc.decode(tc.fixture[:len(tc.fixture)-1])
+			ag_require.ErrorIs(t, err, ErrInvalidExtensionLength)
+			_, err = tc.decode(concat(tc.fixture, []byte{0}))
+			ag_require.ErrorIs(t, err, ErrInvalidExtensionLength)
+		})
+	}
+}
+
+func TestOptionalPubkey_NoneIsAllZero(t *testing.T) {
+	s, err := DecodeMintCloseAuthorityState(repeatByte(0, 32))
+	ag_require.NoError(t, err)
+	ag_require.True(t, s.CloseAuthority.IsNone())
+	ag_require.Nil(t, s.CloseAuthority.Get())
+	ag_require.Equal(t, repeatByte(0, 32), marshalStateBytes(t, s))
+}
+
+func TestPodBool_NonzeroIsTrue(t *testing.T) {
+	// The on-chain PodBool treats any nonzero byte as true; byte 2 must not
+	// be rejected. Re-encoding normalizes to 1.
+	s, err := DecodeCpiGuardState([]byte{2})
+	ag_require.NoError(t, err)
+	ag_require.True(t, s.LockCpi)
+	ag_require.Equal(t, []byte{1}, marshalStateBytes(t, s))
+}
+
+func TestDecodeTokenMetadataState_TrailingBytes(t *testing.T) {
+	authority := pubkeyOf(0x0F)
+	meta := TokenMetadataState{
+		UpdateAuthority: NewOptionalPubkey(&authority),
+		Mint:            pubkeyOf(10),
+		Name:            "N",
+		Symbol:          "S",
+		Uri:             "U",
+	}
+	payload := marshalStateBytes(t, meta)
+
+	got, err := DecodeTokenMetadataState(payload)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, meta.Name, got.Name)
+
+	_, err = DecodeTokenMetadataState(concat(payload, []byte{0}))
+	ag_require.ErrorIs(t, err, ErrInvalidExtensionLength)
+}
+
+func TestAccountState_String(t *testing.T) {
+	ag_require.Equal(t, "Uninitialized", AccountStateUninitialized.String())
+	ag_require.Equal(t, "Initialized", AccountStateInitialized.String())
+	ag_require.Equal(t, "Frozen", AccountStateFrozen.String())
+	ag_require.Equal(t, "AccountState(5)", AccountState(5).String())
+}
+
+func TestExtensionType_String(t *testing.T) {
+	ag_require.Equal(t, "TransferFeeConfig", ExtensionTransferFeeConfig.String())
+	ag_require.Equal(t, "TokenMetadata", ExtensionTokenMetadata.String())
+	ag_require.Equal(t, "Uninitialized", ExtensionUninitialized.String())
+	ag_require.Equal(t, "ExtensionType(999)", ExtensionType(999).String())
+}
+
+func TestExtensionType_Sides(t *testing.T) {
+	mintSide := []ExtensionType{
+		ExtensionTransferFeeConfig, ExtensionMintCloseAuthority, ExtensionConfidentialTransferMint,
+		ExtensionDefaultAccountState, ExtensionNonTransferable, ExtensionInterestBearingConfig,
+		ExtensionPermanentDelegate, ExtensionTransferHook, ExtensionConfidentialTransferFeeConfig,
+		ExtensionMetadataPointer, ExtensionTokenMetadata, ExtensionGroupPointer, ExtensionTokenGroup,
+		ExtensionGroupMemberPointer, ExtensionTokenGroupMember, ExtensionConfidentialMintBurn,
+		ExtensionScaledUiAmount, ExtensionPausable, ExtensionPermissionedBurn,
+	}
+	accountSide := []ExtensionType{
+		ExtensionTransferFeeAmount, ExtensionConfidentialTransferAccount, ExtensionImmutableOwner,
+		ExtensionMemoTransfer, ExtensionCpiGuard, ExtensionNonTransferableAccount,
+		ExtensionTransferHookAccount, ExtensionConfidentialTransferFeeAmount, ExtensionPausableAccount,
+	}
+	for _, e := range mintSide {
+		ag_require.True(t, e.IsMintExtension(), e.String())
+		ag_require.False(t, e.IsAccountExtension(), e.String())
+	}
+	for _, e := range accountSide {
+		ag_require.True(t, e.IsAccountExtension(), e.String())
+		ag_require.False(t, e.IsMintExtension(), e.String())
+	}
+	ag_require.False(t, ExtensionUninitialized.IsMintExtension())
+	ag_require.False(t, ExtensionUninitialized.IsAccountExtension())
+	ag_require.False(t, ExtensionType(999).IsMintExtension())
+	ag_require.False(t, ExtensionType(999).IsAccountExtension())
+}
+
+func TestCalculateLen(t *testing.T) {
+	// No extensions: base sizes.
+	n, err := CalculateMintLen(nil)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, MINT_SIZE, n)
+	n, err = CalculateTokenAccountLen(nil)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, ACCOUNT_SIZE, n)
+
+	// Worked example from the Rust interface: TransferFeeConfig +
+	// MetadataPointer = 166 + (4+108) + (4+64) = 346.
+	n, err = CalculateMintLen([]ExtensionType{ExtensionTransferFeeConfig, ExtensionMetadataPointer})
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, 346, n)
+
+	// Duplicates count once.
+	n, err = CalculateMintLen([]ExtensionType{
+		ExtensionTransferFeeConfig, ExtensionTransferFeeConfig, ExtensionMetadataPointer,
+	})
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, 346, n)
+
+	// A total of exactly 355 (multisig length) is bumped to 357:
+	// 166 + (4+80) + (4+64) + (4+33) = 355 -> 357.
+	n, err = CalculateMintLen([]ExtensionType{ExtensionTokenGroup, ExtensionMetadataPointer, ExtensionPausable})
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, 357, n)
+
+	// Zero-length markers still cost the 4-byte header.
+	n, err = CalculateTokenAccountLen([]ExtensionType{ExtensionImmutableOwner})
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, 170, n)
+
+	// Variable-length and unknown types cannot be sized.
+	_, err = CalculateMintLen([]ExtensionType{ExtensionTokenMetadata})
+	ag_require.ErrorIs(t, err, ErrUnsizedExtension)
+	_, err = CalculateMintLen([]ExtensionType{ExtensionType(999)})
+	ag_require.ErrorIs(t, err, ErrUnsizedExtension)
+}
+
+func TestParseExtensions_TerminatorAndTruncation(t *testing.T) {
+	entry := concat(u16LE(uint16(ExtensionMintCloseAuthority)), u16LE(32), repeatByte(0x11, 32))
+
+	// A zeroed tail is the normal terminator: nothing after type 0 is parsed.
+	tlvs, err := ParseExtensions(concat(entry, repeatByte(0, 40)))
+	ag_require.NoError(t, err)
+	ag_require.Len(t, tlvs, 1)
+	ag_require.Equal(t, ExtensionMintCloseAuthority, tlvs[0].Type)
+
+	// A single trailing byte is legal.
+	tlvs, err = ParseExtensions(concat(entry, []byte{7}))
+	ag_require.NoError(t, err)
+	ag_require.Len(t, tlvs, 1)
+
+	// A nonzero type with a truncated length field is an error.
+	_, err = ParseExtensions(concat(entry, u16LE(uint16(ExtensionCpiGuard)), []byte{1}))
+	ag_require.ErrorIs(t, err, ErrInvalidAccountData)
+
+	// A value overrunning the buffer is an error; parsed entries are kept.
+	tlvs, err = ParseExtensions(concat(entry, u16LE(uint16(ExtensionMintCloseAuthority)), u16LE(32), repeatByte(0x22, 10)))
+	ag_require.ErrorIs(t, err, ErrInvalidAccountData)
+	ag_require.Len(t, tlvs, 1)
+
+	// Empty data parses to no extensions.
+	tlvs, err = ParseExtensions(nil)
+	ag_require.NoError(t, err)
+	ag_require.Empty(t, tlvs)
+}
+
+func TestGetExtensionData(t *testing.T) {
+	tlvs := []ExtensionTLV{
+		{Type: ExtensionCpiGuard, Length: 1, Data: []byte{1}},
+		{Type: ExtensionMemoTransfer, Length: 1, Data: []byte{0}},
+	}
+	d, ok := GetExtensionData(tlvs, ExtensionMemoTransfer)
+	ag_require.True(t, ok)
+	ag_require.Equal(t, []byte{0}, d)
+	_, ok = GetExtensionData(tlvs, ExtensionTransferFeeAmount)
+	ag_require.False(t, ok)
+}
+
+func TestMintDecode_PopulatesReceiver(t *testing.T) {
+	// Regression: Mint.Decode used to decode into a discarded local copy.
+	var mint Mint
+	err := mint.Decode(testMintSlice)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, uint64(42), mint.Supply)
+	ag_require.Equal(t, uint8(7), mint.Decimals)
+	ag_require.NotNil(t, mint.MintAuthority)
+	ag_require.Equal(t, pubkeyOf(1), *mint.MintAuthority)
+}
+
+func TestExtensionInfoTableConsistency(t *testing.T) {
+	// Every declared extension type is present in the table exactly as
+	// declared, and no side flag overlaps.
+	for et := ExtensionUninitialized; et <= ExtensionPermissionedBurn; et++ {
+		info, ok := extensionInfos[et]
+		ag_require.True(t, ok, "missing table entry for %d", uint16(et))
+		if et == ExtensionUninitialized {
+			continue
+		}
+		ag_require.False(t, info.mint && info.account, "%s is flagged for both sides", et)
+		ag_require.True(t, info.mint || info.account, "%s has no side", et)
+		if info.variable {
+			ag_require.Equal(t, 0, info.length)
+		}
+	}
+	ag_require.Len(t, extensionInfos, 29)
+}

--- a/programs/token-2022/extension_fuzz_test.go
+++ b/programs/token-2022/extension_fuzz_test.go
@@ -1,0 +1,78 @@
+package token2022
+
+import (
+	"bytes"
+	"encoding/base64"
+	"testing"
+)
+
+// The fuzz targets check two invariants of the strict decoders on arbitrary
+// input: they never panic, and any data that decodes successfully re-encodes
+// deterministically (decode -> encode -> decode -> encode is a fixed point;
+// the first encode may legally differ from the input by dropping trailing
+// TLV slack).
+
+func fuzzSeeds(f *testing.F) {
+	f.Helper()
+	mainnet, err := base64.StdEncoding.DecodeString(mainnetXStockMintB64)
+	if err != nil {
+		f.Fatal(err)
+	}
+	f.Add([]byte{})
+	f.Add(testMintSlice)
+	f.Add(testAccountSlice)
+	f.Add(mintWithAccountType())
+	f.Add(mintWithExtension())
+	f.Add(accountWithExtension())
+	f.Add(mainnet)
+}
+
+func FuzzDecodeMintWithExtensions(f *testing.F) {
+	fuzzSeeds(f)
+	f.Fuzz(func(t *testing.T, data []byte) {
+		m, err := DecodeMintWithExtensions(data)
+		if err != nil {
+			return
+		}
+		out, err := m.MarshalBinary()
+		if err != nil {
+			t.Fatalf("decoded mint failed to re-encode: %v", err)
+		}
+		m2, err := DecodeMintWithExtensions(out)
+		if err != nil {
+			t.Fatalf("re-encoded mint failed to decode: %v", err)
+		}
+		out2, err := m2.MarshalBinary()
+		if err != nil {
+			t.Fatalf("second re-encode failed: %v", err)
+		}
+		if !bytes.Equal(out, out2) {
+			t.Fatalf("encode is not a fixed point:\nfirst:  %x\nsecond: %x", out, out2)
+		}
+	})
+}
+
+func FuzzDecodeAccountWithExtensions(f *testing.F) {
+	fuzzSeeds(f)
+	f.Fuzz(func(t *testing.T, data []byte) {
+		a, err := DecodeAccountWithExtensions(data)
+		if err != nil {
+			return
+		}
+		out, err := a.MarshalBinary()
+		if err != nil {
+			t.Fatalf("decoded account failed to re-encode: %v", err)
+		}
+		a2, err := DecodeAccountWithExtensions(out)
+		if err != nil {
+			t.Fatalf("re-encoded account failed to decode: %v", err)
+		}
+		out2, err := a2.MarshalBinary()
+		if err != nil {
+			t.Fatalf("second re-encode failed: %v", err)
+		}
+		if !bytes.Equal(out, out2) {
+			t.Fatalf("encode is not a fixed point:\nfirst:  %x\nsecond: %x", out, out2)
+		}
+	})
+}

--- a/programs/token-2022/extension_math.go
+++ b/programs/token-2022/extension_math.go
@@ -1,0 +1,358 @@
+package token2022
+
+import (
+	"fmt"
+	"math"
+	"math/big"
+	"math/bits"
+	"strconv"
+	"strings"
+)
+
+// This file ports the extension helper math from the Rust
+// spl-token-2022-interface crate: transfer-fee calculation, interest-bearing
+// and scaled-UI-amount conversions. The implementations mirror the Rust
+// semantics exactly, including f64 rounding behavior, ceiling division in
+// 128-bit arithmetic, and saturating float-to-u64 casts.
+
+// MaxFeeBasisPoints is the maximum possible fee in basis points: 100%.
+const MaxFeeBasisPoints uint16 = 10_000
+
+const (
+	oneInBasisPoints = uint64(MaxFeeBasisPoints)
+	// secondsPerYear mirrors the Rust constant: 60 * 60 * 24 * 365.24.
+	secondsPerYear = 31_556_736.0
+)
+
+// maxU64AsF64 is u64::MAX as f64 in Rust: 2^64 (the nearest representable value).
+const maxU64AsF64 = float64(1 << 64)
+
+// --- shared helpers ---
+
+// ceilDiv128 returns ceil((hi,lo) / d) as a 128-bit quotient, mirroring the
+// Rust TransferFee::ceil_div over u128. d must be nonzero.
+func ceilDiv128(hi, lo, d uint64) (qhi, qlo uint64) {
+	lo, carry := bits.Add64(lo, d-1, 0)
+	hi += carry // cannot overflow: hi < 2^64-1 for all callers
+	qhi = hi / d
+	rem := hi % d
+	qlo, _ = bits.Div64(rem, lo, d)
+	return qhi, qlo
+}
+
+// checkedSubI64 mirrors Rust i64::checked_sub.
+func checkedSubI64(a, b int64) (int64, bool) {
+	diff := a - b
+	if (b > 0 && diff > a) || (b < 0 && diff < a) {
+		return 0, false
+	}
+	return diff, true
+}
+
+// saturatingF64ToU64 mirrors the Rust `as u64` cast: values of 2^64 or above
+// saturate to u64::MAX, negative values and NaN become 0. The explicit NaN
+// branch matters: a bare Go conversion of NaN is implementation-defined.
+func saturatingF64ToU64(v float64) uint64 {
+	if math.IsNaN(v) {
+		return 0
+	}
+	if v >= maxU64AsF64 {
+		return math.MaxUint64
+	}
+	if v <= 0 {
+		return 0
+	}
+	return uint64(v)
+}
+
+// formatFixedF64 formats v with the given number of fraction digits, matching
+// Rust's format!("{:.N}", v) (including "inf"/"-inf"/"NaN" spellings).
+func formatFixedF64(v float64, decimals uint8) string {
+	switch {
+	case math.IsInf(v, 1):
+		return "inf"
+	case math.IsInf(v, -1):
+		return "-inf"
+	case math.IsNaN(v):
+		return "NaN"
+	}
+	return strconv.FormatFloat(v, 'f', int(decimals), 64)
+}
+
+// trimUiAmountString mirrors the Rust trim_ui_amount_string helper: for a
+// nonzero decimals value, excess trailing zeroes and an unneeded decimal
+// point are trimmed.
+func trimUiAmountString(uiAmount string, decimals uint8) string {
+	if decimals > 0 {
+		uiAmount = strings.TrimRight(uiAmount, "0")
+		uiAmount = strings.TrimRight(uiAmount, ".")
+	}
+	return uiAmount
+}
+
+// parseUiAmountF64 parses a UI amount string the way Rust's f64::from_str
+// does. Go's strconv.ParseFloat additionally accepts digit-separating
+// underscores ("1_000") and hexadecimal floats ("0x1p4"), which Rust rejects;
+// those are filtered out for parity. (A "p" exponent is only reachable
+// through the hex prefix, so rejecting "x" covers it.)
+func parseUiAmountF64(uiAmount string) (float64, error) {
+	if strings.ContainsAny(uiAmount, "_xX") {
+		return 0, fmt.Errorf("%w: %q", ErrInvalidUiAmount, uiAmount)
+	}
+	v, err := strconv.ParseFloat(uiAmount, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %q", ErrInvalidUiAmount, uiAmount)
+	}
+	return v, nil
+}
+
+// --- TransferFee math ---
+
+// CalculateFee calculates the transfer fee for the given pre-fee amount,
+// rounding up and capping at MaximumFee.
+func (f TransferFee) CalculateFee(preFeeAmount uint64) (uint64, error) {
+	bps := uint64(f.TransferFeeBasisPoints)
+	if bps == 0 || preFeeAmount == 0 {
+		return 0, nil
+	}
+	hi, lo := bits.Mul64(preFeeAmount, bps)
+	qhi, qlo := ceilDiv128(hi, lo, oneInBasisPoints)
+	if qhi != 0 {
+		return 0, ErrCalculationOverflow
+	}
+	return min(qlo, f.MaximumFee), nil
+}
+
+// CalculatePostFeeAmount calculates the gross transfer amount after deducting fees.
+func (f TransferFee) CalculatePostFeeAmount(preFeeAmount uint64) (uint64, error) {
+	fee, err := f.CalculateFee(preFeeAmount)
+	if err != nil {
+		return 0, err
+	}
+	if fee > preFeeAmount {
+		return 0, ErrCalculationOverflow
+	}
+	return preFeeAmount - fee, nil
+}
+
+// CalculatePreFeeAmount calculates the transfer amount that will result in
+// the specified net transfer amount.
+//
+// The original transfer amount may not always be unique due to rounding; in
+// that case the smaller amount is chosen. On large net transfer amounts the
+// original amount may overflow, in which case an error is returned.
+func (f TransferFee) CalculatePreFeeAmount(postFeeAmount uint64) (uint64, error) {
+	maximumFee := f.MaximumFee
+	bps := uint64(f.TransferFeeBasisPoints)
+	switch {
+	case bps == 0:
+		// no fee, same amount
+		return postFeeAmount, nil
+	case postFeeAmount == 0:
+		// 0 out, 0 in
+		return 0, nil
+	case bps == oneInBasisPoints:
+		// 100%, cap at max fee
+		sum, carry := bits.Add64(maximumFee, postFeeAmount, 0)
+		if carry != 0 {
+			return 0, ErrCalculationOverflow
+		}
+		return sum, nil
+	default:
+		if bps > oneInBasisPoints {
+			// denominator would underflow (checked_sub in Rust)
+			return 0, ErrCalculationOverflow
+		}
+		hi, lo := bits.Mul64(postFeeAmount, oneInBasisPoints)
+		qhi, qlo := ceilDiv128(hi, lo, oneInBasisPoints-bps)
+		// (raw_pre_fee_amount - post_fee_amount) >= maximum_fee, in 128 bits.
+		dlo, borrow := bits.Sub64(qlo, postFeeAmount, 0)
+		dhi, borrow := bits.Sub64(qhi, 0, borrow)
+		if borrow != 0 {
+			return 0, ErrCalculationOverflow
+		}
+		if dhi > 0 || dlo >= maximumFee {
+			sum, carry := bits.Add64(postFeeAmount, maximumFee, 0)
+			if carry != 0 {
+				return 0, ErrCalculationOverflow
+			}
+			return sum, nil
+		}
+		if qhi != 0 {
+			// pre-fee amount does not fit in u64
+			return 0, ErrCalculationOverflow
+		}
+		return qlo, nil
+	}
+}
+
+// CalculateInverseFee calculates the fee that would produce the given output.
+//
+// Note: this is not an exact inverse of CalculateFee; only
+// CalculateFee(x) >= CalculateInverseFee(x - CalculateFee(x)) holds.
+func (f TransferFee) CalculateInverseFee(postFeeAmount uint64) (uint64, error) {
+	preFeeAmount, err := f.CalculatePreFeeAmount(postFeeAmount)
+	if err != nil {
+		return 0, err
+	}
+	return f.CalculateFee(preFeeAmount)
+}
+
+// GetEpochFee returns the fee schedule active in the given epoch.
+func (s TransferFeeConfigState) GetEpochFee(epoch uint64) TransferFee {
+	if epoch >= s.NewerTransferFee.Epoch {
+		return s.NewerTransferFee
+	}
+	return s.OlderTransferFee
+}
+
+// CalculateEpochFee calculates the fee for the given epoch and input amount.
+func (s TransferFeeConfigState) CalculateEpochFee(epoch uint64, preFeeAmount uint64) (uint64, error) {
+	return s.GetEpochFee(epoch).CalculateFee(preFeeAmount)
+}
+
+// CalculateInverseEpochFee calculates the fee for the given epoch and output amount.
+func (s TransferFeeConfigState) CalculateInverseEpochFee(epoch uint64, postFeeAmount uint64) (uint64, error) {
+	return s.GetEpochFee(epoch).CalculateInverseFee(postFeeAmount)
+}
+
+// --- InterestBearingConfig math ---
+
+func (s InterestBearingConfigState) preUpdateExp() (float64, bool) {
+	timespan, ok := checkedSubI64(s.LastUpdateTimestamp, s.InitializationTimestamp)
+	if !ok {
+		return 0, false
+	}
+	exponent := float64(s.PreUpdateAverageRate) * float64(timespan) / secondsPerYear / float64(oneInBasisPoints)
+	return math.Exp(exponent), true
+}
+
+func (s InterestBearingConfigState) postUpdateExp(unixTimestamp int64) (float64, bool) {
+	timespan, ok := checkedSubI64(unixTimestamp, s.LastUpdateTimestamp)
+	if !ok {
+		return 0, false
+	}
+	exponent := float64(s.CurrentRate) * float64(timespan) / secondsPerYear / float64(oneInBasisPoints)
+	return math.Exp(exponent), true
+}
+
+// totalScale mirrors the Rust total_scale. Note: Go's math.Pow10 is
+// correctly rounded, while Rust's 10_f64.powi can double-round for exponents
+// where 10^n is not exactly representable (23-27, 29-31); results may differ
+// in the last ulp for such uncommon decimals values.
+func (s InterestBearingConfigState) totalScale(decimals uint8, unixTimestamp int64) (float64, bool) {
+	pre, ok := s.preUpdateExp()
+	if !ok {
+		return 0, false
+	}
+	post, ok := s.postUpdateExp(unixTimestamp)
+	if !ok {
+		return 0, false
+	}
+	return pre * post / math.Pow10(int(decimals)), true
+}
+
+// AmountToUiAmount converts a raw amount to its UI representation, accruing
+// continuously-compounded interest up to the given unix timestamp. Excess
+// zeroes and an unneeded decimal point are trimmed.
+func (s InterestBearingConfigState) AmountToUiAmount(amount uint64, decimals uint8, unixTimestamp int64) (string, error) {
+	scale, ok := s.totalScale(decimals, unixTimestamp)
+	if !ok {
+		return "", ErrCalculationOverflow
+	}
+	scaledAmountWithInterest := float64(amount) * scale
+	uiAmount := formatFixedF64(scaledAmountWithInterest, decimals)
+	return trimUiAmountString(uiAmount, decimals), nil
+}
+
+// UiAmountToAmount converts a UI representation of a token amount back to its
+// raw amount, mirroring the Rust try_ui_amount_into_amount (the result is
+// rounded and saturates at u64::MAX).
+func (s InterestBearingConfigState) UiAmountToAmount(uiAmount string, decimals uint8, unixTimestamp int64) (uint64, error) {
+	scaledAmount, err := parseUiAmountF64(uiAmount)
+	if err != nil {
+		return 0, err
+	}
+	scale, ok := s.totalScale(decimals, unixTimestamp)
+	if !ok {
+		return 0, ErrCalculationOverflow
+	}
+	amount := scaledAmount / scale
+	if amount > maxU64AsF64 || amount < 0 || math.IsNaN(amount) {
+		return 0, fmt.Errorf("%w: %q", ErrInvalidUiAmount, uiAmount)
+	}
+	// Rounding must happen last; rounding earlier gives wrong "inf" answers.
+	return saturatingF64ToU64(math.Round(amount)), nil
+}
+
+// TimeWeightedAverageRate returns the time-weighted average of the current
+// and average rates, in basis points.
+func (s InterestBearingConfigState) TimeWeightedAverageRate(currentTimestamp int64) (int16, error) {
+	// Mirrors the Rust i128 arithmetic exactly via big.Int: overflow is
+	// impossible mid-computation, only the final i16 conversion can fail.
+	r1 := big.NewInt(int64(s.PreUpdateAverageRate))
+	t1 := new(big.Int).Sub(big.NewInt(s.LastUpdateTimestamp), big.NewInt(s.InitializationTimestamp))
+	r2 := big.NewInt(int64(s.CurrentRate))
+	t2 := new(big.Int).Sub(big.NewInt(currentTimestamp), big.NewInt(s.LastUpdateTimestamp))
+	totalTimespan := new(big.Int).Add(t1, t2)
+
+	var averageRate *big.Int
+	if totalTimespan.Sign() == 0 {
+		// Happens in testing situations; just use the new rate since the
+		// earlier one was never practically used.
+		averageRate = r2
+	} else {
+		sum := new(big.Int).Add(new(big.Int).Mul(r1, t1), new(big.Int).Mul(r2, t2))
+		averageRate = new(big.Int).Quo(sum, totalTimespan)
+	}
+	if !averageRate.IsInt64() {
+		return 0, ErrCalculationOverflow
+	}
+	v := averageRate.Int64()
+	if v < math.MinInt16 || v > math.MaxInt16 {
+		return 0, ErrCalculationOverflow
+	}
+	return int16(v), nil
+}
+
+// --- ScaledUiAmountConfig math ---
+
+// CurrentMultiplier returns the multiplier active at the given unix timestamp.
+func (s ScaledUiAmountState) CurrentMultiplier(unixTimestamp int64) float64 {
+	if unixTimestamp >= s.NewMultiplierEffectiveTimestamp {
+		return s.NewMultiplier
+	}
+	return s.Multiplier
+}
+
+// totalMultiplier mirrors the Rust total_multiplier; see the math.Pow10
+// rounding note on InterestBearingConfigState.totalScale.
+func (s ScaledUiAmountState) totalMultiplier(decimals uint8, unixTimestamp int64) float64 {
+	return s.CurrentMultiplier(unixTimestamp) / math.Pow10(int(decimals))
+}
+
+// AmountToUiAmount converts a raw amount to its UI representation using the
+// given decimals field. The value is converted to a float and truncated
+// towards zero; excess zeroes and an unneeded decimal point are trimmed.
+func (s ScaledUiAmountState) AmountToUiAmount(amount uint64, decimals uint8, unixTimestamp int64) (string, error) {
+	scaledAmount := float64(amount) * s.CurrentMultiplier(unixTimestamp)
+	truncatedAmount := math.Trunc(scaledAmount) / math.Pow10(int(decimals))
+	uiAmount := formatFixedF64(truncatedAmount, decimals)
+	return trimUiAmountString(uiAmount, decimals), nil
+}
+
+// UiAmountToAmount converts a UI representation of a token amount back to its
+// raw amount. The string is parsed to a float, scaled, and truncated towards
+// zero (saturating at u64::MAX), mirroring the Rust try_ui_amount_into_amount.
+func (s ScaledUiAmountState) UiAmountToAmount(uiAmount string, decimals uint8, unixTimestamp int64) (uint64, error) {
+	scaledAmount, err := parseUiAmountF64(uiAmount)
+	if err != nil {
+		return 0, err
+	}
+	amount := scaledAmount / s.totalMultiplier(decimals, unixTimestamp)
+	if amount > maxU64AsF64 || amount < 0 || math.IsNaN(amount) {
+		return 0, fmt.Errorf("%w: %q", ErrInvalidUiAmount, uiAmount)
+	}
+	// Truncation must happen last; truncating earlier gives wrong "inf" answers.
+	return saturatingF64ToU64(math.Trunc(amount)), nil
+}

--- a/programs/token-2022/extension_math_test.go
+++ b/programs/token-2022/extension_math_test.go
@@ -1,0 +1,555 @@
+package token2022
+
+import (
+	"math"
+	"testing"
+
+	ag_require "github.com/stretchr/testify/require"
+)
+
+// The tests in this file are ported 1:1 from the Rust
+// spl-token-2022-interface crate:
+//   - src/extension/transfer_fee/mod.rs
+//   - src/extension/interest_bearing_mint/mod.rs
+//   - src/extension/scaled_ui_amount/mod.rs
+// The Rust proptest property tests (round_trip_fee_calculation,
+// inverse_fee_relationship, time_weighted_average_calc, amount_to_ui_amount)
+// are not ported; the deterministic tests are ported verbatim.
+
+const (
+	testNewerEpoch = uint64(100)
+	testOlderEpoch = uint64(1)
+	// INT_SECONDS_PER_YEAR in the Rust tests: 6 * 6 * 24 * 36524.
+	intSecondsPerYear = int64(6 * 6 * 24 * 36524)
+	testDecimals      = uint8(2)
+)
+
+// testTransferFeeConfig mirrors the Rust test_transfer_fee_config fixture.
+func testTransferFeeConfig() TransferFeeConfigState {
+	authority := pubkeyOf(10)
+	withdraw := pubkeyOf(11)
+	return TransferFeeConfigState{
+		TransferFeeConfigAuthority: NewOptionalPubkey(&authority),
+		WithdrawWithheldAuthority:  NewOptionalPubkey(&withdraw),
+		WithheldAmount:             math.MaxUint64,
+		OlderTransferFee: TransferFee{
+			Epoch:                  testOlderEpoch,
+			MaximumFee:             10,
+			TransferFeeBasisPoints: 100,
+		},
+		NewerTransferFee: TransferFee{
+			Epoch:                  testNewerEpoch,
+			MaximumFee:             5_000,
+			TransferFeeBasisPoints: 1,
+		},
+	}
+}
+
+func TestTransferFee_EpochFee(t *testing.T) {
+	config := testTransferFeeConfig()
+	// during epoch 100 and after, use newer transfer fee
+	ag_require.Equal(t, testNewerEpoch, config.GetEpochFee(testNewerEpoch).Epoch)
+	ag_require.Equal(t, testNewerEpoch, config.GetEpochFee(testNewerEpoch+1).Epoch)
+	ag_require.Equal(t, testNewerEpoch, config.GetEpochFee(math.MaxUint64).Epoch)
+	// before that, use older transfer fee
+	ag_require.Equal(t, testOlderEpoch, config.GetEpochFee(testNewerEpoch-1).Epoch)
+	ag_require.Equal(t, testOlderEpoch, config.GetEpochFee(testOlderEpoch).Epoch)
+	ag_require.Equal(t, testOlderEpoch, config.GetEpochFee(testOlderEpoch+1).Epoch)
+}
+
+// requireFee returns a helper that unwraps (value, error) pairs from the fee
+// calculation methods, failing the test on error.
+func requireFee(t *testing.T) func(uint64, error) uint64 {
+	return func(v uint64, err error) uint64 {
+		t.Helper()
+		ag_require.NoError(t, err)
+		return v
+	}
+}
+
+func TestTransferFee_CalculateFeeMax(t *testing.T) {
+	fee := requireFee(t)
+	one := oneInBasisPoints
+	transferFee := TransferFee{Epoch: 0, MaximumFee: 5_000, TransferFeeBasisPoints: 1}
+	maximumFee := transferFee.MaximumFee
+	// hit maximum fee
+	ag_require.Equal(t, maximumFee, fee(transferFee.CalculateFee(math.MaxUint64)))
+	// at exactly the max
+	ag_require.Equal(t, maximumFee, fee(transferFee.CalculateFee(maximumFee*one)))
+	// one token above, normally rounds up, but we're at the max
+	ag_require.Equal(t, maximumFee, fee(transferFee.CalculateFee(maximumFee*one+1)))
+	// one token below, rounds up to the max
+	ag_require.Equal(t, maximumFee, fee(transferFee.CalculateFee(maximumFee*one-1)))
+}
+
+func TestTransferFee_CalculateFeeMin(t *testing.T) {
+	fee := requireFee(t)
+	one := oneInBasisPoints
+	transferFee := TransferFee{Epoch: 0, MaximumFee: 5_000, TransferFeeBasisPoints: 1}
+	minimumFee := uint64(1)
+	// hit minimum fee even with 1 token
+	ag_require.Equal(t, minimumFee, fee(transferFee.CalculateFee(1)))
+	// still minimum at 2 tokens
+	ag_require.Equal(t, minimumFee, fee(transferFee.CalculateFee(2)))
+	// still minimum at 10_000 tokens
+	ag_require.Equal(t, minimumFee, fee(transferFee.CalculateFee(one)))
+	// 2 token fee at 10_001
+	ag_require.Equal(t, minimumFee+1, fee(transferFee.CalculateFee(one+1)))
+	// zero is always zero
+	ag_require.Equal(t, uint64(0), fee(transferFee.CalculateFee(0)))
+}
+
+func TestTransferFee_CalculateFeeZero(t *testing.T) {
+	fee := requireFee(t)
+	one := oneInBasisPoints
+	transferFee := TransferFee{Epoch: 0, MaximumFee: math.MaxUint64, TransferFeeBasisPoints: 0}
+	// always zero fee
+	ag_require.Equal(t, uint64(0), fee(transferFee.CalculateFee(0)))
+	ag_require.Equal(t, uint64(0), fee(transferFee.CalculateFee(math.MaxUint64)))
+	ag_require.Equal(t, uint64(0), fee(transferFee.CalculateFee(1)))
+	ag_require.Equal(t, uint64(0), fee(transferFee.CalculateFee(one)))
+
+	transferFee = TransferFee{Epoch: 0, MaximumFee: 0, TransferFeeBasisPoints: MaxFeeBasisPoints}
+	// always zero fee
+	ag_require.Equal(t, uint64(0), fee(transferFee.CalculateFee(0)))
+	ag_require.Equal(t, uint64(0), fee(transferFee.CalculateFee(math.MaxUint64)))
+	ag_require.Equal(t, uint64(0), fee(transferFee.CalculateFee(1)))
+	ag_require.Equal(t, uint64(0), fee(transferFee.CalculateFee(one)))
+}
+
+func TestTransferFee_CalculateFeeExactOutMax(t *testing.T) {
+	fee := requireFee(t)
+	one := oneInBasisPoints
+	transferFee := TransferFee{Epoch: 0, MaximumFee: 5_000, TransferFeeBasisPoints: 1}
+	maximumFee := transferFee.MaximumFee
+	// hit maximum fee
+	ag_require.Equal(t, maximumFee, fee(transferFee.CalculateInverseFee(math.MaxUint64-maximumFee)))
+	// at exactly the max
+	ag_require.Equal(t, maximumFee, fee(transferFee.CalculateInverseFee(maximumFee*one-maximumFee)))
+	// one token above, normally rounds up, but we're at the max
+	ag_require.Equal(t, maximumFee, fee(transferFee.CalculateInverseFee(maximumFee*one-maximumFee+1)))
+	// one token below, rounds up to the max
+	ag_require.Equal(t, maximumFee, fee(transferFee.CalculateInverseFee(maximumFee*one-maximumFee-1)))
+}
+
+func TestTransferFee_CalculatePreFeeAmountEdgeCases(t *testing.T) {
+	fee := requireFee(t)
+	maximumFee := uint64(5_000)
+	transferFee := TransferFee{Epoch: 0, MaximumFee: maximumFee, TransferFeeBasisPoints: MaxFeeBasisPoints}
+
+	// 0 zero out, 0 in
+	ag_require.Equal(t, uint64(0), fee(transferFee.CalculatePreFeeAmount(0)))
+
+	// cap at max fee
+	ag_require.Equal(t, 1+maximumFee, fee(transferFee.CalculatePreFeeAmount(1)))
+
+	// no fee same amount
+	transferFee = TransferFee{Epoch: 0, MaximumFee: maximumFee, TransferFeeBasisPoints: 0}
+	ag_require.Equal(t, uint64(1), fee(transferFee.CalculatePreFeeAmount(1)))
+}
+
+func TestTransferFee_CalculateFeeExactOutMin(t *testing.T) {
+	fee := requireFee(t)
+	one := oneInBasisPoints
+	transferFee := TransferFee{Epoch: 0, MaximumFee: 5_000, TransferFeeBasisPoints: 1}
+	minimumFee := uint64(1)
+	// hit minimum fee even with 1 token
+	ag_require.Equal(t, minimumFee, fee(transferFee.CalculateInverseFee(1)))
+	// still minimum at 2 tokens
+	ag_require.Equal(t, minimumFee, fee(transferFee.CalculateInverseFee(2)))
+	// still minimum at 9_999 tokens
+	ag_require.Equal(t, minimumFee, fee(transferFee.CalculateInverseFee(one-1)))
+	// 2 token fee at 10_000
+	ag_require.Equal(t, minimumFee+1, fee(transferFee.CalculateInverseFee(one)))
+}
+
+// --- InterestBearingConfig ---
+
+func TestInterestBearing_SecondsPerYear(t *testing.T) {
+	ag_require.Equal(t, 31_556_736.0, secondsPerYear)
+	ag_require.Equal(t, int64(31_556_736), intSecondsPerYear)
+}
+
+func TestInterestBearing_SpecificAmountToUiAmount(t *testing.T) {
+	const one = uint64(1_000_000_000_000_000_000)
+	// constant 5%
+	config := InterestBearingConfigState{
+		InitializationTimestamp: 0,
+		PreUpdateAverageRate:    500,
+		LastUpdateTimestamp:     intSecondsPerYear,
+		CurrentRate:             500,
+	}
+	// 1 year at 5% gives a total of exp(0.05) = 1.0512710963760241
+	ui, err := config.AmountToUiAmount(one, 18, intSecondsPerYear)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, "1.051271096376024117", ui)
+	// with 1 decimal place
+	ui, err = config.AmountToUiAmount(one, 19, intSecondsPerYear)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, "0.1051271096376024117", ui)
+	// with 10 decimal places
+	ui, err = config.AmountToUiAmount(one, 28, intSecondsPerYear)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, "0.0000000001051271096376024175", ui) // different digits at the end!
+
+	// huge amount with 10 decimal places
+	ui, err = config.AmountToUiAmount(10_000_000_000, 10, intSecondsPerYear)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, "1.0512710964", ui)
+
+	// negative
+	config = InterestBearingConfigState{
+		InitializationTimestamp: 0,
+		PreUpdateAverageRate:    -500,
+		LastUpdateTimestamp:     intSecondsPerYear,
+		CurrentRate:             -500,
+	}
+	// 1 year at -5% gives a total of exp(-0.05) = 0.951229424500714
+	ui, err = config.AmountToUiAmount(one, 18, intSecondsPerYear)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, "0.951229424500713905", ui)
+
+	// net out
+	config = InterestBearingConfigState{
+		InitializationTimestamp: 0,
+		PreUpdateAverageRate:    -500,
+		LastUpdateTimestamp:     intSecondsPerYear,
+		CurrentRate:             500,
+	}
+	// 1 year at -5% and 1 year at 5% gives a total of 1
+	ui, err = config.AmountToUiAmount(1, 0, intSecondsPerYear*2)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, "1", ui)
+
+	// huge values
+	config = InterestBearingConfigState{
+		InitializationTimestamp: 0,
+		PreUpdateAverageRate:    500,
+		LastUpdateTimestamp:     intSecondsPerYear,
+		CurrentRate:             500,
+	}
+	ui, err = config.AmountToUiAmount(math.MaxUint64, 0, intSecondsPerYear*2)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, "20386805083448098816", ui)
+	ui, err = config.AmountToUiAmount(math.MaxUint64, 0, intSecondsPerYear*10_000)
+	ag_require.NoError(t, err)
+	// there's an underflow risk, but it works!
+	ag_require.Equal(t, "258917064265813826192025834755112557504850551118283225815045099303279643822914042296793377611277551888244755303462190670431480816358154467489350925148558569427069926786360814068189956495940285398273555561779717914539956777398245259214848", ui)
+}
+
+func TestInterestBearing_SpecificUiAmountToAmount(t *testing.T) {
+	// constant 5%
+	config := InterestBearingConfigState{
+		InitializationTimestamp: 0,
+		PreUpdateAverageRate:    500,
+		LastUpdateTimestamp:     intSecondsPerYear,
+		CurrentRate:             500,
+	}
+	// 1 year at 5% gives a total of exp(0.05) = 1.0512710963760241
+	amount, err := config.UiAmountToAmount("1.0512710963760241", 0, intSecondsPerYear)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, uint64(1), amount)
+	// with 1 decimal place
+	amount, err = config.UiAmountToAmount("0.10512710963760241", 1, intSecondsPerYear)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, uint64(1), amount)
+	// with 10 decimal places
+	amount, err = config.UiAmountToAmount("0.00000000010512710963760242", 10, intSecondsPerYear)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, uint64(1), amount)
+
+	// huge amount with 10 decimal places
+	amount, err = config.UiAmountToAmount("1.0512710963760241", 10, intSecondsPerYear)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, uint64(10_000_000_000), amount)
+
+	// negative
+	config = InterestBearingConfigState{
+		InitializationTimestamp: 0,
+		PreUpdateAverageRate:    -500,
+		LastUpdateTimestamp:     intSecondsPerYear,
+		CurrentRate:             -500,
+	}
+	// 1 year at -5% gives a total of exp(-0.05) = 0.951229424500714
+	amount, err = config.UiAmountToAmount("0.951229424500714", 0, intSecondsPerYear)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, uint64(1), amount)
+
+	// net out
+	config = InterestBearingConfigState{
+		InitializationTimestamp: 0,
+		PreUpdateAverageRate:    -500,
+		LastUpdateTimestamp:     intSecondsPerYear,
+		CurrentRate:             500,
+	}
+	// 1 year at -5% and 1 year at 5% gives a total of 1
+	amount, err = config.UiAmountToAmount("1", 0, intSecondsPerYear*2)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, uint64(1), amount)
+
+	// huge values
+	config = InterestBearingConfigState{
+		InitializationTimestamp: 0,
+		PreUpdateAverageRate:    500,
+		LastUpdateTimestamp:     intSecondsPerYear,
+		CurrentRate:             500,
+	}
+	amount, err = config.UiAmountToAmount("20386805083448100000", 0, intSecondsPerYear*2)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, uint64(math.MaxUint64), amount)
+}
+
+func TestInterestBearing_SpecificAmountToUiAmountNoInterest(t *testing.T) {
+	config := InterestBearingConfigState{
+		InitializationTimestamp: 0,
+		PreUpdateAverageRate:    0,
+		LastUpdateTimestamp:     intSecondsPerYear,
+		CurrentRate:             0,
+	}
+	for _, tc := range []struct {
+		amount   uint64
+		expected string
+	}{
+		{23, "0.23"}, {110, "1.1"}, {4200, "42"}, {0, "0"},
+	} {
+		ui, err := config.AmountToUiAmount(tc.amount, testDecimals, intSecondsPerYear)
+		ag_require.NoError(t, err)
+		ag_require.Equal(t, tc.expected, ui)
+	}
+}
+
+func TestInterestBearing_SpecificUiAmountToAmountNoInterest(t *testing.T) {
+	config := InterestBearingConfigState{
+		InitializationTimestamp: 0,
+		PreUpdateAverageRate:    0,
+		LastUpdateTimestamp:     intSecondsPerYear,
+		CurrentRate:             0,
+	}
+	for _, tc := range []struct {
+		uiAmount string
+		expected uint64
+	}{
+		{"0.23", 23}, {"0.20", 20}, {"0.2000", 20}, {".2", 20},
+		{"1.1", 110}, {"1.10", 110}, {"42", 4200}, {"42.", 4200}, {"0", 0},
+	} {
+		amount, err := config.UiAmountToAmount(tc.uiAmount, testDecimals, intSecondsPerYear)
+		ag_require.NoError(t, err)
+		ag_require.Equal(t, tc.expected, amount)
+	}
+
+	// this is invalid with normal mints, but rounding for this mint makes it ok
+	amount, err := config.UiAmountToAmount("0.111", testDecimals, intSecondsPerYear)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, uint64(11), amount)
+
+	// fail if invalid ui_amount passed in
+	for _, uiAmount := range []string{"", ".", "0.t"} {
+		_, err := config.UiAmountToAmount(uiAmount, testDecimals, intSecondsPerYear)
+		ag_require.ErrorIs(t, err, ErrInvalidUiAmount)
+	}
+}
+
+func TestParseUiAmount_RejectsGoLiteralSyntax(t *testing.T) {
+	// Rust's f64::from_str rejects digit-separating underscores and hex
+	// floats; Go's strconv.ParseFloat accepts them, so the parser filters
+	// them out explicitly for parity.
+	config := ScaledUiAmountState{
+		Multiplier:                      1.0,
+		NewMultiplierEffectiveTimestamp: 1,
+	}
+	for _, uiAmount := range []string{"1_000", "1_0.5", "0x1p4", "0X1P4"} {
+		_, err := config.UiAmountToAmount(uiAmount, 0, 0)
+		ag_require.ErrorIs(t, err, ErrInvalidUiAmount, uiAmount)
+	}
+}
+
+// --- ScaledUiAmountConfig ---
+
+func TestScaledUiAmount_MultiplierChoice(t *testing.T) {
+	multiplier := 5.0
+	newMultiplier := 10.0
+	effectiveTimestamp := int64(1)
+	config := ScaledUiAmountState{
+		Multiplier:                      multiplier,
+		NewMultiplier:                   newMultiplier,
+		NewMultiplierEffectiveTimestamp: effectiveTimestamp,
+	}
+	ag_require.Equal(t, newMultiplier, config.CurrentMultiplier(effectiveTimestamp))
+	ag_require.Equal(t, multiplier, config.CurrentMultiplier(effectiveTimestamp-1))
+	ag_require.Equal(t, multiplier, config.CurrentMultiplier(0))
+	ag_require.Equal(t, multiplier, config.CurrentMultiplier(math.MinInt64))
+	ag_require.Equal(t, newMultiplier, config.CurrentMultiplier(math.MaxInt64))
+}
+
+func TestScaledUiAmount_SpecificAmountToUiAmount(t *testing.T) {
+	// 5x
+	config := ScaledUiAmountState{
+		Multiplier:                      5.0,
+		NewMultiplierEffectiveTimestamp: 1,
+	}
+	ui, err := config.AmountToUiAmount(1, 0, 0)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, "5", ui)
+	// with 1 decimal place
+	ui, err = config.AmountToUiAmount(1, 1, 0)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, "0.5", ui)
+	// with 10 decimal places
+	ui, err = config.AmountToUiAmount(1, 10, 0)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, "0.0000000005", ui)
+
+	// huge amount with 10 decimal places
+	ui, err = config.AmountToUiAmount(10_000_000_000, 10, 0)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, "5", ui)
+
+	// huge values
+	config = ScaledUiAmountState{
+		Multiplier:                      math.MaxFloat64,
+		NewMultiplierEffectiveTimestamp: 1,
+	}
+	ui, err = config.AmountToUiAmount(math.MaxUint64, 0, 0)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, "inf", ui)
+
+	// truncation
+	config = ScaledUiAmountState{
+		Multiplier:                      0.99,
+		NewMultiplierEffectiveTimestamp: 1,
+	}
+	// This is really 0.99999... but it gets truncated
+	ui, err = config.AmountToUiAmount(101, 2, 0)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, "0.99", ui)
+}
+
+func TestScaledUiAmount_SpecificUiAmountToAmount(t *testing.T) {
+	// constant 5x
+	config := ScaledUiAmountState{
+		Multiplier:                      5.0,
+		NewMultiplierEffectiveTimestamp: 1,
+	}
+	amount, err := config.UiAmountToAmount("5.0", 0, 0)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, uint64(1), amount)
+	// with 1 decimal place
+	amount, err = config.UiAmountToAmount("0.500000000", 1, 0)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, uint64(1), amount)
+	// with 10 decimal places
+	amount, err = config.UiAmountToAmount("0.00000000050000000000000000", 10, 0)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, uint64(1), amount)
+
+	// huge amount with 10 decimal places
+	amount, err = config.UiAmountToAmount("5.0000000000000000", 10, 0)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, uint64(10_000_000_000), amount)
+
+	// huge values
+	amount, err = config.UiAmountToAmount("92233720368547758075", 0, 0)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, uint64(math.MaxUint64), amount)
+
+	config = ScaledUiAmountState{
+		Multiplier:                      math.MaxFloat64,
+		NewMultiplierEffectiveTimestamp: 1,
+	}
+	// scientific notation "e"
+	amount, err = config.UiAmountToAmount("1.7976931348623157e308", 0, 0)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, uint64(1), amount)
+
+	config = ScaledUiAmountState{
+		Multiplier:                      9.745314011399998e288,
+		NewMultiplierEffectiveTimestamp: 1,
+	}
+	amount, err = config.UiAmountToAmount("1.7976931348623157e308", 0, 0)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, uint64(math.MaxUint64), amount)
+	// scientific notation "E"
+	amount, err = config.UiAmountToAmount("1.7976931348623157E308", 0, 0)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, uint64(math.MaxUint64), amount)
+
+	// this is unfortunate, but underflows can happen due to floats
+	config = ScaledUiAmountState{
+		Multiplier:                      1.0,
+		NewMultiplierEffectiveTimestamp: 1,
+	}
+	amount, err = config.UiAmountToAmount("18446744073709551616", 0, 0) // u64::MAX + 1
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, uint64(math.MaxUint64), amount)
+
+	// overflow u64 fail
+	config = ScaledUiAmountState{
+		Multiplier:                      0.1,
+		NewMultiplierEffectiveTimestamp: 1,
+	}
+	_, err = config.UiAmountToAmount("18446744073709551615", 0, 0)
+	ag_require.ErrorIs(t, err, ErrInvalidUiAmount)
+
+	for _, failUiAmount := range []string{"-0.0000000000000000000001", "inf", "-inf", "NaN"} {
+		_, err = config.UiAmountToAmount(failUiAmount, 0, 0)
+		ag_require.ErrorIs(t, err, ErrInvalidUiAmount)
+	}
+
+	// truncation
+	config = ScaledUiAmountState{
+		Multiplier:                      0.99,
+		NewMultiplierEffectiveTimestamp: 1,
+	}
+	// There are a few possibilities for what "0.99" means, it could be 101
+	// or 100 underlying tokens, but the result gives the fewest possible
+	// tokens that give that UI amount.
+	amount, err = config.UiAmountToAmount("0.99", 2, 0)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, uint64(100), amount)
+}
+
+func TestScaledUiAmount_SpecificAmountToUiAmountNoScale(t *testing.T) {
+	config := ScaledUiAmountState{
+		Multiplier:                      1.0,
+		NewMultiplierEffectiveTimestamp: 1,
+	}
+	for _, tc := range []struct {
+		amount   uint64
+		expected string
+	}{
+		{23, "0.23"}, {110, "1.1"}, {4200, "42"}, {0, "0"},
+	} {
+		ui, err := config.AmountToUiAmount(tc.amount, testDecimals, 0)
+		ag_require.NoError(t, err)
+		ag_require.Equal(t, tc.expected, ui)
+	}
+}
+
+func TestScaledUiAmount_SpecificUiAmountToAmountNoScale(t *testing.T) {
+	config := ScaledUiAmountState{
+		Multiplier:                      1.0,
+		NewMultiplierEffectiveTimestamp: 1,
+	}
+	for _, tc := range []struct {
+		uiAmount string
+		expected uint64
+	}{
+		{"0.23", 23}, {"0.20", 20}, {"0.2000", 20}, {".2", 20},
+		{"1.1", 110}, {"1.10", 110}, {"42", 4200}, {"42.", 4200}, {"0", 0},
+	} {
+		amount, err := config.UiAmountToAmount(tc.uiAmount, testDecimals, 0)
+		ag_require.NoError(t, err)
+		ag_require.Equal(t, tc.expected, amount)
+	}
+
+	// this is invalid with normal mints, but truncation for this mint makes it ok
+	amount, err := config.UiAmountToAmount("0.111", testDecimals, 0)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, uint64(11), amount)
+
+	// fail if invalid ui_amount passed in
+	for _, uiAmount := range []string{"", ".", "0.t"} {
+		_, err := config.UiAmountToAmount(uiAmount, testDecimals, 0)
+		ag_require.ErrorIs(t, err, ErrInvalidUiAmount)
+	}
+}

--- a/programs/token-2022/extension_rust_parity_test.go
+++ b/programs/token-2022/extension_rust_parity_test.go
@@ -1,0 +1,406 @@
+package token2022
+
+import (
+	"encoding/base64"
+	"testing"
+
+	ag_solanago "github.com/gagliardetto/solana-go"
+	ag_require "github.com/stretchr/testify/require"
+)
+
+// The tests in this file are ported from the test module of
+// interface/src/extension/mod.rs in the Rust token-2022 repository, using the
+// same byte fixtures. Tests that exercise the program-runtime mutable API
+// (alloc, realloc, init_extension, set_account_type) are not applicable to
+// this client-side port and are represented by their decode-visible effects.
+
+// mintWithAccountType mirrors the Rust MINT_WITH_ACCOUNT_TYPE fixture:
+// base mint, zero padding to offset 165, AccountType::Mint.
+func mintWithAccountType() []byte {
+	return concat(testMintSlice, repeatByte(0, 83), []byte{1})
+}
+
+// mintWithExtension mirrors the Rust MINT_WITH_EXTENSION fixture:
+// mintWithAccountType plus a MintCloseAuthority TLV entry of [1; 32].
+func mintWithExtension() []byte {
+	return concat(mintWithAccountType(), []byte{3, 0, 32, 0}, repeatByte(1, 32))
+}
+
+// accountWithExtension mirrors the Rust ACCOUNT_WITH_EXTENSION fixture:
+// base account, AccountType::Account, and a TransferHookAccount TLV entry.
+func accountWithExtension() []byte {
+	return concat(testAccountSlice, []byte{2}, []byte{15, 0, 1, 0, 1})
+}
+
+// Ported from mod.rs unpack_opaque_buffer.
+func TestRustParity_UnpackOpaqueBuffer(t *testing.T) {
+	// Mint with account type byte but no TLV entries.
+	m, err := DecodeMintWithExtensions(mintWithAccountType())
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, uint64(42), m.Mint.Supply)
+	ag_require.False(t, m.HasExtensions())
+
+	// Mint with a MintCloseAuthority extension.
+	m, err = DecodeMintWithExtensions(mintWithExtension())
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, uint64(42), m.Mint.Supply)
+	ag_require.NotNil(t, m.MintCloseAuthority)
+	ag_require.Equal(t, pubkeyOf(1), m.MintCloseAuthority.CloseAuthority.Key)
+	// TransferFeeConfig is not present (Rust: get_extension errors).
+	ag_require.Nil(t, m.TransferFeeConfig)
+
+	// Unpacking mint data as an account fails (Rust: UninitializedAccount).
+	_, err = DecodeAccountWithExtensions(mintWithExtension())
+	ag_require.Error(t, err)
+
+	// Plain base mint slice decodes with no extensions.
+	m, err = DecodeMintWithExtensions(testMintSlice)
+	ag_require.NoError(t, err)
+	ag_require.False(t, m.HasExtensions())
+
+	// Account with a TransferHookAccount extension.
+	a, err := DecodeAccountWithExtensions(accountWithExtension())
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, uint64(3), a.Account.Amount)
+	ag_require.NotNil(t, a.TransferHookAccount)
+	ag_require.True(t, a.TransferHookAccount.Transferring)
+
+	// Unpacking account data as a mint fails (Rust: InvalidAccountData).
+	_, err = DecodeMintWithExtensions(accountWithExtension())
+	ag_require.ErrorIs(t, err, ErrInvalidAccountData)
+
+	// Plain base account slice decodes with no extensions.
+	a, err = DecodeAccountWithExtensions(testAccountSlice)
+	ag_require.NoError(t, err)
+	ag_require.False(t, a.HasExtensions())
+}
+
+// Ported from mod.rs mint_fail_unpack_opaque_buffer.
+func TestRustParity_MintFailUnpackOpaqueBuffer(t *testing.T) {
+	// input buffer too small
+	_, err := DecodeMintWithExtensions([]byte{0, 3})
+	ag_require.ErrorIs(t, err, ErrInvalidAccountData)
+
+	// tweak the account type
+	buffer := mintWithExtension()
+	buffer[ACCOUNT_SIZE] = 3
+	_, err = DecodeMintWithExtensions(buffer)
+	ag_require.ErrorIs(t, err, ErrInvalidAccountData)
+
+	// clear the mint initialized byte
+	buffer = mintWithExtension()
+	buffer[45] = 0
+	_, err = DecodeMintWithExtensions(buffer)
+	ag_require.ErrorIs(t, err, ErrUninitializedAccount)
+
+	// tweak the padding
+	buffer = mintWithExtension()
+	buffer[MINT_SIZE] = 100
+	_, err = DecodeMintWithExtensions(buffer)
+	ag_require.ErrorIs(t, err, ErrInvalidAccountData)
+
+	// tweak the extension type to an account extension (TransferFeeAmount).
+	// Rust defers the error to get_extension; our decoder rejects eagerly.
+	buffer = mintWithExtension()
+	buffer[ACCOUNT_SIZE+1] = 2
+	_, err = DecodeMintWithExtensions(buffer)
+	ag_require.ErrorIs(t, err, ErrExtensionTypeMismatch)
+
+	// tweak the length, too big: the value overruns the buffer
+	buffer = mintWithExtension()
+	buffer[ACCOUNT_SIZE+3] = 100
+	_, err = DecodeMintWithExtensions(buffer)
+	ag_require.ErrorIs(t, err, ErrInvalidAccountData)
+
+	// tweak the length, too small: the remaining bytes parse as garbage TLV
+	buffer = mintWithExtension()
+	buffer[ACCOUNT_SIZE+3] = 10
+	_, err = DecodeMintWithExtensions(buffer)
+	ag_require.Error(t, err)
+
+	// data buffer is too small
+	buffer = mintWithExtension()
+	_, err = DecodeMintWithExtensions(buffer[:len(buffer)-1])
+	ag_require.ErrorIs(t, err, ErrInvalidAccountData)
+}
+
+// Ported from mod.rs account_fail_unpack_opaque_buffer.
+func TestRustParity_AccountFailUnpackOpaqueBuffer(t *testing.T) {
+	// input buffer too small
+	_, err := DecodeAccountWithExtensions([]byte{0, 3})
+	ag_require.ErrorIs(t, err, ErrInvalidAccountData)
+
+	// all 5's: not a valid AccountState
+	_, err = DecodeAccountWithExtensions(repeatByte(5, ACCOUNT_SIZE))
+	ag_require.ErrorIs(t, err, ErrUninitializedAccount)
+
+	// tweak the account type
+	buffer := accountWithExtension()
+	buffer[ACCOUNT_SIZE] = 3
+	_, err = DecodeAccountWithExtensions(buffer)
+	ag_require.ErrorIs(t, err, ErrInvalidAccountData)
+
+	// clear the state byte
+	buffer = accountWithExtension()
+	buffer[108] = 0
+	_, err = DecodeAccountWithExtensions(buffer)
+	ag_require.ErrorIs(t, err, ErrUninitializedAccount)
+
+	// tweak the extension type to a mint extension (PermanentDelegate)
+	buffer = accountWithExtension()
+	buffer[ACCOUNT_SIZE+1] = 12
+	_, err = DecodeAccountWithExtensions(buffer)
+	ag_require.ErrorIs(t, err, ErrExtensionTypeMismatch)
+
+	// tweak the length, too big
+	buffer = accountWithExtension()
+	buffer[ACCOUNT_SIZE+3] = 100
+	_, err = DecodeAccountWithExtensions(buffer)
+	ag_require.ErrorIs(t, err, ErrInvalidAccountData)
+
+	// tweak the length, larger than the remaining value bytes
+	buffer = accountWithExtension()
+	buffer[ACCOUNT_SIZE+3] = 10
+	_, err = DecodeAccountWithExtensions(buffer)
+	ag_require.ErrorIs(t, err, ErrInvalidAccountData)
+
+	// data buffer is too small
+	buffer = accountWithExtension()
+	_, err = DecodeAccountWithExtensions(buffer[:len(buffer)-1])
+	ag_require.ErrorIs(t, err, ErrInvalidAccountData)
+}
+
+// Ported from mod.rs get_extension_types_with_opaque_buffer, against the raw
+// TLV walker.
+func TestRustParity_GetExtensionTypesWithOpaqueBuffer(t *testing.T) {
+	// incorrect due to the length
+	_, err := ParseExtensions([]byte{1, 0, 1, 1})
+	ag_require.ErrorIs(t, err, ErrInvalidAccountData)
+
+	// huge enum number: Rust rejects unknown extension types; this port
+	// deliberately tolerates them for forward compatibility.
+	tlvs, err := ParseExtensions([]byte{0, 1, 0, 0})
+	ag_require.NoError(t, err)
+	ag_require.Len(t, tlvs, 1)
+	ag_require.Equal(t, ExtensionType(256), tlvs[0].Type)
+
+	// correct: good enum number and zero length
+	tlvs, err = ParseExtensions([]byte{1, 0, 0, 0})
+	ag_require.NoError(t, err)
+	ag_require.Len(t, tlvs, 1)
+	ag_require.Equal(t, ExtensionTransferFeeConfig, tlvs[0].Type)
+	ag_require.Equal(t, uint16(0), tlvs[0].Length)
+
+	// correct: just uninitialized data at the end
+	tlvs, err = ParseExtensions([]byte{0, 0})
+	ag_require.NoError(t, err)
+	ag_require.Empty(t, tlvs)
+}
+
+// Ported from mod.rs mint_extension_any_order.
+func TestRustParity_MintExtensionAnyOrder(t *testing.T) {
+	closeAuthorityEntry := tlvEntry(ExtensionMintCloseAuthority, repeatByte(1, 32))
+	feeConfigEntry := tlvEntry(ExtensionTransferFeeConfig, marshalStateBytes(t, testTransferFeeConfig()))
+
+	buffer := extendedMintData(closeAuthorityEntry, feeConfigEntry)
+	otherBuffer := extendedMintData(feeConfigEntry, closeAuthorityEntry)
+
+	// buffers are NOT the same because written in a different order
+	ag_require.NotEqual(t, buffer, otherBuffer)
+
+	state, err := DecodeMintWithExtensions(buffer)
+	ag_require.NoError(t, err)
+	otherState, err := DecodeMintWithExtensions(otherBuffer)
+	ag_require.NoError(t, err)
+
+	// BUT mint and extensions are the same
+	ag_require.Equal(t, state.TransferFeeConfig, otherState.TransferFeeConfig)
+	ag_require.Equal(t, state.MintCloseAuthority, otherState.MintCloseAuthority)
+	ag_require.Equal(t, state.Mint, otherState.Mint)
+
+	// and each re-encodes byte-exactly in its own order
+	out, err := state.MarshalBinary()
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, buffer, out)
+	out, err = otherState.MarshalBinary()
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, otherBuffer, out)
+}
+
+// Ported from mod.rs mint_with_multisig_len / account_with_multisig_len.
+// The Rust test uses the test-only MintPaddingTest (65535) and
+// AccountPaddingTest (65534) extensions, 185 bytes each, chosen so the total
+// lands exactly on the 355-byte multisig length and gets padded to 357.
+func TestRustParity_MultisigLen(t *testing.T) {
+	// A buffer of exactly Multisig::LEN is never valid extended state.
+	_, err := DecodeMintWithExtensions(make([]byte, multisigSize))
+	ag_require.ErrorIs(t, err, ErrInvalidAccountData)
+	_, err = DecodeAccountWithExtensions(make([]byte, multisigSize))
+	ag_require.ErrorIs(t, err, ErrInvalidAccountData)
+
+	// Mint: the expected raw buffer from the Rust test, terminator included.
+	expect := concat(
+		testMintSlice,
+		repeatByte(0, 83),
+		[]byte{1},
+		u16LE(65535), u16LE(185), repeatByte(1, 185),
+		u16LE(0),
+	)
+	ag_require.Equal(t, multisigSize+2, len(expect))
+
+	m, err := DecodeMintWithExtensions(expect)
+	ag_require.NoError(t, err)
+	ag_require.Len(t, m.Unknown, 1)
+	ag_require.Equal(t, ExtensionType(65535), m.Unknown[0].Type)
+	ag_require.Equal(t, repeatByte(1, 185), m.Unknown[0].Data)
+
+	out, err := m.MarshalBinary()
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, expect, out)
+
+	// Account: same shape with AccountPaddingTest (65534).
+	expect = concat(
+		testAccountSlice,
+		[]byte{2},
+		u16LE(65534), u16LE(185), repeatByte(1, 185),
+		u16LE(0),
+	)
+	ag_require.Equal(t, multisigSize+2, len(expect))
+
+	a, err := DecodeAccountWithExtensions(expect)
+	ag_require.NoError(t, err)
+	ag_require.Len(t, a.Unknown, 1)
+	ag_require.Equal(t, ExtensionType(65534), a.Unknown[0].Type)
+
+	out, err = a.MarshalBinary()
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, expect, out)
+}
+
+// Ported from mod.rs mint_without_extensions.
+func TestRustParity_MintWithoutExtensions(t *testing.T) {
+	space, err := CalculateMintLen(nil)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, MINT_SIZE, space)
+
+	// unpacking base mint data as an account fails
+	_, err = DecodeAccountWithExtensions(testMintSlice)
+	ag_require.ErrorIs(t, err, ErrInvalidAccountData)
+
+	// a mint without extensions round-trips to exactly the base slice
+	m, err := DecodeMintWithExtensions(testMintSlice)
+	ag_require.NoError(t, err)
+	out, err := m.MarshalBinary()
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, testMintSlice, out)
+}
+
+// Ported from mod.rs test_extension_with_no_data.
+func TestRustParity_ExtensionWithNoData(t *testing.T) {
+	accountSize, err := CalculateTokenAccountLen([]ExtensionType{ExtensionImmutableOwner})
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, ACCOUNT_SIZE+1+4, accountSize)
+
+	data := extendedAccountData(tlvEntry(ExtensionImmutableOwner, nil))
+	ag_require.Equal(t, accountSize, len(data))
+
+	a, err := DecodeAccountWithExtensions(data)
+	ag_require.NoError(t, err)
+	ag_require.True(t, a.ImmutableOwner)
+
+	tlvs, err := ParseExtensions(data[tlvStartOffset:])
+	ag_require.NoError(t, err)
+	ag_require.Len(t, tlvs, 1)
+	ag_require.Equal(t, ExtensionImmutableOwner, tlvs[0].Type)
+	ag_require.Equal(t, uint16(0), tlvs[0].Length)
+}
+
+// Ported from mod.rs fail_account_len_with_metadata.
+func TestRustParity_FailAccountLenWithMetadata(t *testing.T) {
+	_, err := CalculateMintLen([]ExtensionType{
+		ExtensionMintCloseAuthority,
+		ExtensionTokenMetadata,
+		ExtensionTransferFeeConfig,
+	})
+	ag_require.ErrorIs(t, err, ErrUnsizedExtension)
+}
+
+// mainnetXStockMintB64 is the on-chain account data of the token-2022 mint
+// Xs3oZwbHvqis4NYcf4YKWmEia2eC84wSiVrcYcTqpH8 (SpaceX xStock), fetched from
+// mainnet at slot 437873054. 679 bytes, 8 extensions.
+const mainnetXStockMintB64 = "AQAAAGVqQkIv6okUBqQZ0dHeCPQqhHlBtaGulevOYZrDFyk0XOODfu4yAAAIAQEAAAD/3+wbzSzTg5PITaoIyRzA041nf/jQq3tdAz8A9zLMMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARIAQABD+fHuLje4B+pFy3TmAJcivsAJKWAm5ORVi0NeJKXpxgfoA5u0rUz3nDg+Q8DFHdGFN0BRK3nQ+UISkjRR0AODDAAgAEP58e4uN7gH6kXLdOYAlyK+wAkpYCbk5FWLQ14kpenGBgABAAEZADgABm9ZIlHMR3R4JaWa0UIupDVz9SjaXe4q94ErMU+ZReMAAAAAAADwPwAAAAAAAAAAAAAAAAAA8D8aACEA/9/sG80s04OTyE2qCMkcwNONZ3/40Kt7XQM/APcyzDAABABBAEP58e4uN7gH6kXLdOYAlyK+wAkpYCbk5FWLQ14kpenGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADgBAAEP58e4uN7gH6kXLdOYAlyK+wAkpYCbk5FWLQ14kpenGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATAKYAQ/nx7i43uAfqRct05gCXIr7ACSlgJuTkVYtDXiSl6cYH6AObtK1M95w4PkPAxR3RhTdAUSt50PlCEpI0UdADgw0AAABTcGFjZVggeFN0b2NrBQAAAFNQQ1h4RAAAAGh0dHBzOi8veHN0b2Nrcy1tZXRhZGF0YS5iYWNrZWQuZmkvdG9rZW5zL1NvbGFuYS9TUENYeC9tZXRhZGF0YS5qc29uAAAAAA=="
+
+// TestMainnetVector_XStockMint decodes a real mainnet token-2022 mint with
+// eight extensions and re-encodes it byte-exactly.
+func TestMainnetVector_XStockMint(t *testing.T) {
+	data, err := base64.StdEncoding.DecodeString(mainnetXStockMintB64)
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, 679, len(data))
+
+	m, err := DecodeMintWithExtensions(data)
+	ag_require.NoError(t, err)
+
+	// Base mint.
+	backedAuthority := ag_solanago.MustPublicKeyFromBase58("7pt9tkctJPK7PPNQJ77GKg8ZffSF6QxoMiCFYHxrtaCj")
+	freezeAuthority := ag_solanago.MustPublicKeyFromBase58("JDq14BWvqCRFNu1krb12bcRpbGtJZ1FLEakMw6FdxJNs")
+	ag_require.NotNil(t, m.Mint.MintAuthority)
+	ag_require.Equal(t, backedAuthority, *m.Mint.MintAuthority)
+	ag_require.NotNil(t, m.Mint.FreezeAuthority)
+	ag_require.Equal(t, freezeAuthority, *m.Mint.FreezeAuthority)
+	ag_require.Equal(t, uint64(55999906177884), m.Mint.Supply)
+	ag_require.Equal(t, uint8(8), m.Mint.Decimals)
+	ag_require.True(t, m.Mint.IsInitialized)
+
+	mintAddress := ag_solanago.MustPublicKeyFromBase58("Xs3oZwbHvqis4NYcf4YKWmEia2eC84wSiVrcYcTqpH8")
+	adminAuthority := ag_solanago.MustPublicKeyFromBase58("5aMNNLQJwAEeoemTEMkv5NVjqKwvvefRYCQ5Z67HFvEq")
+
+	// MetadataPointer: points at the mint itself.
+	ag_require.NotNil(t, m.MetadataPointer)
+	ag_require.Equal(t, adminAuthority, m.MetadataPointer.Authority.Key)
+	ag_require.Equal(t, mintAddress, m.MetadataPointer.MetadataAddress.Key)
+
+	// PermanentDelegate.
+	ag_require.NotNil(t, m.PermanentDelegate)
+	ag_require.Equal(t, adminAuthority, m.PermanentDelegate.Delegate.Key)
+
+	// DefaultAccountState: Initialized.
+	ag_require.NotNil(t, m.DefaultAccountState)
+	ag_require.Equal(t, AccountStateInitialized, m.DefaultAccountState.State)
+
+	// ScaledUiAmount: multiplier 1.0, effective from timestamp 0.
+	ag_require.NotNil(t, m.ScaledUiAmount)
+	ag_require.Equal(t, 1.0, m.ScaledUiAmount.Multiplier)
+	ag_require.Equal(t, int64(0), m.ScaledUiAmount.NewMultiplierEffectiveTimestamp)
+	ag_require.Equal(t, 1.0, m.ScaledUiAmount.NewMultiplier)
+
+	// Pausable: not paused.
+	ag_require.NotNil(t, m.Pausable)
+	ag_require.Equal(t, freezeAuthority, m.Pausable.Authority.Key)
+	ag_require.False(t, m.Pausable.Paused)
+
+	// ConfidentialTransferMint: manual approval, no auditor.
+	ag_require.NotNil(t, m.ConfidentialTransferMint)
+	ag_require.Equal(t, adminAuthority, m.ConfidentialTransferMint.Authority.Key)
+	ag_require.False(t, m.ConfidentialTransferMint.AutoApproveNewAccounts)
+	ag_require.Equal(t, [32]byte{}, m.ConfidentialTransferMint.AuditorElGamalPubkey)
+
+	// TransferHook: authority set, no program.
+	ag_require.NotNil(t, m.TransferHook)
+	ag_require.Equal(t, adminAuthority, m.TransferHook.Authority.Key)
+	ag_require.True(t, m.TransferHook.ProgramID.IsNone())
+
+	// TokenMetadata.
+	ag_require.NotNil(t, m.TokenMetadata)
+	ag_require.Equal(t, adminAuthority, m.TokenMetadata.UpdateAuthority.Key)
+	ag_require.Equal(t, mintAddress, m.TokenMetadata.Mint)
+	ag_require.Equal(t, "SpaceX xStock", m.TokenMetadata.Name)
+	ag_require.Equal(t, "SPCXx", m.TokenMetadata.Symbol)
+	ag_require.Equal(t, "https://xstocks-metadata.backed.fi/tokens/Solana/SPCXx/metadata.json", m.TokenMetadata.Uri)
+	ag_require.Empty(t, m.TokenMetadata.AdditionalMetadata)
+
+	// No unknown extensions, and the whole account re-encodes byte-exactly.
+	ag_require.Empty(t, m.Unknown)
+	out, err := m.MarshalBinary()
+	ag_require.NoError(t, err)
+	ag_require.Equal(t, data, out)
+}

--- a/programs/token-2022/extension_states.go
+++ b/programs/token-2022/extension_states.go
@@ -424,6 +424,10 @@ type GroupPointerState struct {
 // --- TokenGroup ---
 
 // TokenGroupState is the extension state for ExtensionTokenGroup.
+//
+// Deprecated: the Size and MaxSize fields have the wrong width (the on-chain
+// layout uses u64, not u32), so this struct cannot represent real account
+// data. Use TokenGroup instead.
 type TokenGroupState struct {
 	// The authority that can update the group.
 	UpdateAuthority OptionalPubkey
@@ -433,6 +437,18 @@ type TokenGroupState struct {
 	Size uint32
 	// The maximum number of group members.
 	MaxSize uint32
+}
+
+// TokenGroup is the extension state for ExtensionTokenGroup (mint extension).
+type TokenGroup struct {
+	// The authority that can update the group.
+	UpdateAuthority OptionalPubkey
+	// The associated mint.
+	Mint solana.PublicKey
+	// The current number of group members.
+	Size uint64
+	// The maximum number of group members.
+	MaxSize uint64
 }
 
 // --- GroupMemberPointer ---
@@ -448,6 +464,10 @@ type GroupMemberPointerState struct {
 // --- TokenGroupMember ---
 
 // TokenGroupMemberState is the extension state for ExtensionTokenGroupMember.
+//
+// Deprecated: the MemberNumber field has the wrong width (the on-chain layout
+// uses u64, not u32), so this struct cannot represent real account data. Use
+// TokenGroupMember instead.
 type TokenGroupMemberState struct {
 	// The associated mint.
 	Mint solana.PublicKey
@@ -457,16 +477,28 @@ type TokenGroupMemberState struct {
 	MemberNumber uint32
 }
 
+// TokenGroupMember is the extension state for ExtensionTokenGroupMember (mint extension).
+type TokenGroupMember struct {
+	// The associated mint.
+	Mint solana.PublicKey
+	// The parent group.
+	Group solana.PublicKey
+	// The member number.
+	MemberNumber uint64
+}
+
 // --- ConfidentialMintBurn ---
 
 // ConfidentialMintBurnState is the extension state for ExtensionConfidentialMintBurn.
 type ConfidentialMintBurnState struct {
-	// Authority to modify the confidential mint burn configuration.
+	// The confidential supply of the mint (encrypted by encryption pubkey).
 	ConfidentialSupply [64]byte
-	// The decryptable supply.
+	// The decryptable supply of the mint (encrypted by decryptable pubkey).
 	DecryptableSupply [36]byte
 	// The ElGamal pubkey used for supply encryption.
 	SupplyElGamalPubkey [32]byte
+	// The amount of burned tokens pending application to the supply.
+	PendingBurn [64]byte
 }
 
 // --- ScaledUiAmount ---
@@ -510,29 +542,61 @@ type PermissionedBurnState struct {
 type ExtensionTLV struct {
 	Type   ExtensionType
 	Length uint16
-	Data   []byte
+	// Data is a view into the account data buffer passed to ParseExtensions,
+	// not a copy: mutating it mutates the source buffer. Its capacity is
+	// capped at its length, so appending to it allocates a fresh slice.
+	Data []byte
 }
 
 // ParseExtensions parses extension TLV entries from raw account data.
 // The data should start after the base account/mint data and the account type byte.
+//
+// Following the token-2022 program semantics, iteration stops at the first
+// entry whose type is ExtensionUninitialized (a zeroed tail is the normal
+// end-of-data marker), and a single trailing byte is tolerated. A nonzero
+// extension type with a truncated length field, or a value that overruns the
+// buffer, is an error; already-parsed entries are returned alongside it.
 func ParseExtensions(data []byte) ([]ExtensionTLV, error) {
 	var extensions []ExtensionTLV
 	offset := 0
-	for offset+4 <= len(data) {
+	for {
+		if len(data)-offset < 2 {
+			// Fewer than 2 bytes left for a type: legal trailing slack.
+			return extensions, nil
+		}
 		extType := ExtensionType(binary.LittleEndian.Uint16(data[offset:]))
+		if extType == ExtensionUninitialized {
+			return extensions, nil
+		}
+		if len(data)-offset < 4 {
+			return extensions, fmt.Errorf("%w: extension length field truncated at offset %d", ErrInvalidAccountData, offset)
+		}
 		extLen := binary.LittleEndian.Uint16(data[offset+2:])
 		offset += 4
-		if offset+int(extLen) > len(data) {
-			return extensions, fmt.Errorf("extension data truncated: need %d bytes, have %d", extLen, len(data)-offset)
+		end := offset + int(extLen)
+		if end > len(data) {
+			return extensions, fmt.Errorf("%w: extension data truncated: need %d bytes, have %d", ErrInvalidAccountData, extLen, len(data)-offset)
 		}
 		extensions = append(extensions, ExtensionTLV{
 			Type:   extType,
 			Length: extLen,
-			Data:   data[offset : offset+int(extLen)],
+			// The three-index slice caps capacity so appends by the caller
+			// cannot overwrite the following TLV entries in place.
+			Data: data[offset:end:end],
 		})
-		offset += int(extLen)
+		offset = end
 	}
-	return extensions, nil
+}
+
+// GetExtensionData returns the raw data of the first TLV entry with the given
+// type, and whether it was found.
+func GetExtensionData(tlvs []ExtensionTLV, t ExtensionType) ([]byte, bool) {
+	for _, tlv := range tlvs {
+		if tlv.Type == t {
+			return tlv.Data, true
+		}
+	}
+	return nil, false
 }
 
 // ParseMintWithExtensions parses a Mint and its extensions from raw account data.

--- a/programs/token-2022/extension_types.go
+++ b/programs/token-2022/extension_types.go
@@ -1,0 +1,176 @@
+package token2022
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Sentinel errors for token-2022 extension state decoding and encoding.
+// They are wrapped with additional context; test with errors.Is.
+var (
+	// ErrInvalidAccountData indicates account data that does not match the
+	// token-2022 layout (bad length, nonzero padding, bad account type byte,
+	// or malformed TLV data).
+	ErrInvalidAccountData = errors.New("token2022: invalid account data")
+	// ErrExtensionNotFound indicates the requested extension is not present.
+	ErrExtensionNotFound = errors.New("token2022: extension not found")
+	// ErrExtensionTypeMismatch indicates an extension found on the wrong kind
+	// of account (a mint extension in token-account data or vice versa).
+	ErrExtensionTypeMismatch = errors.New("token2022: extension type mismatch")
+	// ErrInvalidExtensionLength indicates a TLV entry whose length does not
+	// match the fixed size of its extension type.
+	ErrInvalidExtensionLength = errors.New("token2022: invalid extension length")
+	// ErrDuplicateExtension indicates the same extension type appears more
+	// than once in the TLV data.
+	ErrDuplicateExtension = errors.New("token2022: duplicate extension")
+	// ErrUnsizedExtension indicates an extension type whose data length is
+	// not fixed (TokenMetadata) or not known (unrecognized types), so its
+	// size cannot be calculated from the type alone.
+	ErrUnsizedExtension = errors.New("token2022: extension type has no fixed size")
+	// ErrUninitializedAccount indicates mint or token-account data whose
+	// base state is not initialized (mirrors the unpack checks of the
+	// token-2022 program).
+	ErrUninitializedAccount = errors.New("token2022: account not initialized")
+	// ErrCalculationOverflow indicates that a fee or rate calculation
+	// overflowed (a case where the Rust implementation returns None).
+	ErrCalculationOverflow = errors.New("token2022: calculation overflow")
+	// ErrInvalidUiAmount indicates a UI amount string that cannot be
+	// converted to a raw token amount.
+	ErrInvalidUiAmount = errors.New("token2022: invalid ui amount")
+)
+
+// Absolute offsets shared by extended mints and token accounts: the account
+// type byte sits at offset 165 (mints are zero-padded from 82 up to 165), and
+// TLV entries start at offset 166.
+const (
+	accountTypeOffset = ACCOUNT_SIZE     // 165
+	tlvStartOffset    = ACCOUNT_SIZE + 1 // 166
+	// multisigSize is the length of a Multisig account. Extended mint or
+	// token-account data must never be exactly this long, so encoded data
+	// landing on it is padded by two zero bytes.
+	multisigSize = 355
+)
+
+// extensionInfo describes the wire format of a known extension type.
+type extensionInfo struct {
+	name     string
+	length   int  // fixed data length in bytes; 0 for markers and variable-length types
+	variable bool // true if the data length is instance-dependent (TokenMetadata)
+	mint     bool // valid on mint accounts
+	account  bool // valid on token accounts
+}
+
+var extensionInfos = map[ExtensionType]extensionInfo{
+	ExtensionUninitialized:                 {name: "Uninitialized"},
+	ExtensionTransferFeeConfig:             {name: "TransferFeeConfig", length: 108, mint: true},
+	ExtensionTransferFeeAmount:             {name: "TransferFeeAmount", length: 8, account: true},
+	ExtensionMintCloseAuthority:            {name: "MintCloseAuthority", length: 32, mint: true},
+	ExtensionConfidentialTransferMint:      {name: "ConfidentialTransferMint", length: 65, mint: true},
+	ExtensionConfidentialTransferAccount:   {name: "ConfidentialTransferAccount", length: 295, account: true},
+	ExtensionDefaultAccountState:           {name: "DefaultAccountState", length: 1, mint: true},
+	ExtensionImmutableOwner:                {name: "ImmutableOwner", length: 0, account: true},
+	ExtensionMemoTransfer:                  {name: "MemoTransfer", length: 1, account: true},
+	ExtensionNonTransferable:               {name: "NonTransferable", length: 0, mint: true},
+	ExtensionInterestBearingConfig:         {name: "InterestBearingConfig", length: 52, mint: true},
+	ExtensionCpiGuard:                      {name: "CpiGuard", length: 1, account: true},
+	ExtensionPermanentDelegate:             {name: "PermanentDelegate", length: 32, mint: true},
+	ExtensionNonTransferableAccount:        {name: "NonTransferableAccount", length: 0, account: true},
+	ExtensionTransferHook:                  {name: "TransferHook", length: 64, mint: true},
+	ExtensionTransferHookAccount:           {name: "TransferHookAccount", length: 1, account: true},
+	ExtensionConfidentialTransferFeeConfig: {name: "ConfidentialTransferFeeConfig", length: 129, mint: true},
+	ExtensionConfidentialTransferFeeAmount: {name: "ConfidentialTransferFeeAmount", length: 64, account: true},
+	ExtensionMetadataPointer:               {name: "MetadataPointer", length: 64, mint: true},
+	ExtensionTokenMetadata:                 {name: "TokenMetadata", variable: true, mint: true},
+	ExtensionGroupPointer:                  {name: "GroupPointer", length: 64, mint: true},
+	ExtensionTokenGroup:                    {name: "TokenGroup", length: 80, mint: true},
+	ExtensionGroupMemberPointer:            {name: "GroupMemberPointer", length: 64, mint: true},
+	ExtensionTokenGroupMember:              {name: "TokenGroupMember", length: 72, mint: true},
+	ExtensionConfidentialMintBurn:          {name: "ConfidentialMintBurn", length: 196, mint: true},
+	ExtensionScaledUiAmount:                {name: "ScaledUiAmount", length: 56, mint: true},
+	ExtensionPausable:                      {name: "Pausable", length: 33, mint: true},
+	ExtensionPausableAccount:               {name: "PausableAccount", length: 0, account: true},
+	ExtensionPermissionedBurn:              {name: "PermissionedBurn", length: 32, mint: true},
+}
+
+// String returns the account state name as used by the token-2022 program,
+// or "AccountState(N)" for unknown values.
+func (s AccountState) String() string {
+	switch s {
+	case AccountStateUninitialized:
+		return "Uninitialized"
+	case AccountStateInitialized:
+		return "Initialized"
+	case AccountStateFrozen:
+		return "Frozen"
+	default:
+		return fmt.Sprintf("AccountState(%d)", uint8(s))
+	}
+}
+
+// String returns the extension name as used by the token-2022 program, or
+// "ExtensionType(N)" for unknown values.
+func (t ExtensionType) String() string {
+	if info, ok := extensionInfos[t]; ok {
+		return info.name
+	}
+	return fmt.Sprintf("ExtensionType(%d)", uint16(t))
+}
+
+// TypeLen returns the fixed data length of the extension type in bytes.
+// sized is false for variable-length extensions (TokenMetadata) and for
+// unknown types; zero-length marker extensions return (0, true).
+func (t ExtensionType) TypeLen() (n int, sized bool) {
+	info, ok := extensionInfos[t]
+	if !ok || info.variable {
+		return 0, false
+	}
+	return info.length, true
+}
+
+// IsMintExtension reports whether the extension type applies to mint accounts.
+func (t ExtensionType) IsMintExtension() bool {
+	return extensionInfos[t].mint
+}
+
+// IsAccountExtension reports whether the extension type applies to token accounts.
+func (t ExtensionType) IsAccountExtension() bool {
+	return extensionInfos[t].account
+}
+
+// CalculateMintLen returns the byte length of a mint account with the given
+// extension types, mirroring ExtensionType::try_calculate_account_len in the
+// token-2022 program: duplicates are counted once, no extensions yields
+// MINT_SIZE, and a total of exactly 355 bytes (the multisig length) is bumped
+// to 357. Variable-length and unknown extension types yield an error.
+func CalculateMintLen(types []ExtensionType) (int, error) {
+	return calculateAccountLen(types, MINT_SIZE)
+}
+
+// CalculateTokenAccountLen returns the byte length of a token account with
+// the given extension types. See CalculateMintLen for the exact semantics.
+func CalculateTokenAccountLen(types []ExtensionType) (int, error) {
+	return calculateAccountLen(types, ACCOUNT_SIZE)
+}
+
+func calculateAccountLen(types []ExtensionType, baseSize int) (int, error) {
+	if len(types) == 0 {
+		return baseSize, nil
+	}
+	total := tlvStartOffset
+	seen := make(map[ExtensionType]struct{}, len(types))
+	for _, t := range types {
+		if _, dup := seen[t]; dup {
+			continue
+		}
+		seen[t] = struct{}{}
+		n, sized := t.TypeLen()
+		if !sized {
+			return 0, fmt.Errorf("%w: %s", ErrUnsizedExtension, t)
+		}
+		total += 4 + n
+	}
+	if total == multisigSize {
+		total += 2
+	}
+	return total, nil
+}

--- a/programs/token-2022/rpc.go
+++ b/programs/token-2022/rpc.go
@@ -11,9 +11,8 @@ import (
 const MINT_SIZE = 82
 
 func (mint *Mint) Decode(data []byte) error {
-	mint = new(Mint)
 	dec := bin.NewBinDecoder(data)
-	if err := dec.Decode(&mint); err != nil {
+	if err := mint.UnmarshalWithDecoder(dec); err != nil {
 		return fmt.Errorf("unable to decode mint: %w", err)
 	}
 	return nil


### PR DESCRIPTION
### Problem

token-2022 package declared extension state structs but could not actually decode or encode them:
- no codecs existed for the 22 fixed-size extension states
-  no typed API for reading a mint or token account together with its TLV extensions, and the raw TLV parser diverged from the on-chain program's semantics

### Summary of Changes

- typed high-level API
- codecs for all 22 fixed-size extension states
- extension metadata & helpers
- math helpers

#### Usage Example

mint - https://solscan.io/token/Xs3oZwbHvqis4NYcf4YKWmEia2eC84wSiVrcYcTqpH8

```go
func ExampleDecodeMintWithExtensions() {
	data, err := base64.StdEncoding.DecodeString(xStockMintAccountData)
	if err != nil {
		log.Fatal(err)
	}

	mint, err := token2022.DecodeMintWithExtensions(data)
	if err != nil {
		log.Fatal(err)
	}

	// Base mint state (the same 82-byte layout as the original SPL token).
	fmt.Println("== base mint ==")
	fmt.Println("supply:", mint.Mint.Supply)
	fmt.Println("decimals:", mint.Mint.Decimals)
	fmt.Println("mint authority:", mint.Mint.MintAuthority)
	fmt.Println("freeze authority:", mint.Mint.FreezeAuthority)

	fmt.Println("== MetadataPointer ==")
	fmt.Println("authority:", mint.MetadataPointer.Authority.Get())
	fmt.Println("metadata address:", mint.MetadataPointer.MetadataAddress.Get())

	fmt.Println("== PermanentDelegate ==")
	fmt.Println("delegate:", mint.PermanentDelegate.Delegate.Get())

	fmt.Println("== DefaultAccountState ==")
	fmt.Println("state for new token accounts:", mint.DefaultAccountState.State)

	fmt.Println("== ScaledUiAmount ==")
	fmt.Println("authority:", mint.ScaledUiAmount.Authority.Get())
	fmt.Println("multiplier:", mint.ScaledUiAmount.Multiplier)
	fmt.Println("new multiplier:", mint.ScaledUiAmount.NewMultiplier,
		"effective at unix time", mint.ScaledUiAmount.NewMultiplierEffectiveTimestamp)
	// The extension also converts raw amounts to UI amounts (unix timestamp
	// 0 already selects the new 1.0 multiplier here).
	uiAmount, err := mint.ScaledUiAmount.AmountToUiAmount(mint.Mint.Supply, mint.Mint.Decimals, 0)
	if err != nil {
		log.Fatal(err)
	}
	fmt.Println("ui supply:", uiAmount)

	fmt.Println("== Pausable ==")
	fmt.Println("authority:", mint.Pausable.Authority.Get())
	fmt.Println("paused:", mint.Pausable.Paused)

	fmt.Println("== ConfidentialTransferMint ==")
	fmt.Println("authority:", mint.ConfidentialTransferMint.Authority.Get())
	fmt.Println("auto approve new accounts:", mint.ConfidentialTransferMint.AutoApproveNewAccounts)
	fmt.Println("auditor configured:", mint.ConfidentialTransferMint.AuditorElGamalPubkey != [32]byte{})

	fmt.Println("== TransferHook ==")
	fmt.Println("authority:", mint.TransferHook.Authority.Get())
	fmt.Println("hook program:", mint.TransferHook.ProgramID.Get())

	fmt.Println("== TokenMetadata ==")
	fmt.Println("update authority:", mint.TokenMetadata.UpdateAuthority.Get())
	fmt.Println("mint:", mint.TokenMetadata.Mint)
	fmt.Println("name:", mint.TokenMetadata.Name)
	fmt.Println("symbol:", mint.TokenMetadata.Symbol)
	fmt.Println("uri:", mint.TokenMetadata.Uri)
	fmt.Println("additional metadata fields:", len(mint.TokenMetadata.AdditionalMetadata))

	// MarshalBinary reproduces the on-chain bytes exactly, preserving the
	// original TLV extension order.
	encoded, err := mint.MarshalBinary()
	if err != nil {
		log.Fatal(err)
	}
	fmt.Println("round-trip byte-exact:", bytes.Equal(encoded, data))

	// Output:
	// == base mint ==
	// supply: 55999906177884
	// decimals: 8
	// mint authority: 7pt9tkctJPK7PPNQJ77GKg8ZffSF6QxoMiCFYHxrtaCj
	// freeze authority: JDq14BWvqCRFNu1krb12bcRpbGtJZ1FLEakMw6FdxJNs
	// == MetadataPointer ==
	// authority: 5aMNNLQJwAEeoemTEMkv5NVjqKwvvefRYCQ5Z67HFvEq
	// metadata address: Xs3oZwbHvqis4NYcf4YKWmEia2eC84wSiVrcYcTqpH8
	// == PermanentDelegate ==
	// delegate: 5aMNNLQJwAEeoemTEMkv5NVjqKwvvefRYCQ5Z67HFvEq
	// == DefaultAccountState ==
	// state for new token accounts: Initialized
	// == ScaledUiAmount ==
	// authority: S7vYFFWH6BjJyEsdrPQpqpYTqLTrPRK6KW3VwsJuRaS
	// multiplier: 1
	// new multiplier: 1 effective at unix time 0
	// ui supply: 559999.06177884
	// == Pausable ==
	// authority: JDq14BWvqCRFNu1krb12bcRpbGtJZ1FLEakMw6FdxJNs
	// paused: false
	// == ConfidentialTransferMint ==
	// authority: 5aMNNLQJwAEeoemTEMkv5NVjqKwvvefRYCQ5Z67HFvEq
	// auto approve new accounts: false
	// auditor configured: false
	// == TransferHook ==
	// authority: 5aMNNLQJwAEeoemTEMkv5NVjqKwvvefRYCQ5Z67HFvEq
	// hook program: <nil>
	// == TokenMetadata ==
	// update authority: 5aMNNLQJwAEeoemTEMkv5NVjqKwvvefRYCQ5Z67HFvEq
	// mint: Xs3oZwbHvqis4NYcf4YKWmEia2eC84wSiVrcYcTqpH8
	// name: SpaceX xStock
	// symbol: SPCXx
	// uri: https://xstocks-metadata.backed.fi/tokens/Solana/SPCXx/metadata.json
	// additional metadata fields: 0
	// round-trip byte-exact: true
}
```

cc @HealthyBuilder 