### PR TITLE
fix: getAccountInfo handle not found account

### DIFF
--- a/cmd/slnc/cmd/get_account.go
+++ b/cmd/slnc/cmd/get_account.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
 	json "github.com/goccy/go-json"
 	"github.com/spf13/cobra"
 )
@@ -37,6 +38,9 @@ var getAccountCmd = &cobra.Command{
 		resp, err := client.GetAccountInfo(ctx, solana.MustPublicKeyFromBase58(args[0]))
 		if err != nil {
 			return err
+		}
+		if resp == nil || resp.Value == nil {
+			return rpc.ErrNotFound
 		}
 
 		acct := resp.Value

--- a/cmd/slnc/cmd/token_get_mint.go
+++ b/cmd/slnc/cmd/token_get_mint.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/programs/token"
+	"github.com/gagliardetto/solana-go/rpc"
 	"github.com/ryanuber/columnize"
 	"github.com/spf13/cobra"
 )
@@ -43,6 +44,9 @@ var tokenGetMintCmd = &cobra.Command{
 		acct, err := client.GetAccountInfo(ctx, mintAddress)
 		if err != nil {
 			return fmt.Errorf("couldn't get account data: %w", err)
+		}
+		if acct == nil || acct.Value == nil {
+			return rpc.ErrNotFound
 		}
 
 		mint := &token.Mint{}

--- a/programs/address-lookup-table/address-lookup.go
+++ b/programs/address-lookup-table/address-lookup.go
@@ -35,7 +35,7 @@ func GetAddressLookupTable(
 	if err != nil {
 		return nil, err
 	}
-	if account == nil {
+	if account == nil || account.Value == nil {
 		return nil, fmt.Errorf("account not found")
 	}
 	return DecodeAddressLookupTableState(account.GetBinary())
@@ -51,7 +51,7 @@ func GetAddressLookupTableStateWithOpts(
 	if err != nil {
 		return nil, err
 	}
-	if account == nil {
+	if account == nil || account.Value == nil {
 		return nil, fmt.Errorf("account not found")
 	}
 	return DecodeAddressLookupTableState(account.GetBinary())

--- a/programs/address-lookup-table/address-lookup.go
+++ b/programs/address-lookup-table/address-lookup.go
@@ -36,7 +36,7 @@ func GetAddressLookupTable(
 		return nil, err
 	}
 	if account == nil || account.Value == nil {
-		return nil, fmt.Errorf("account not found")
+		return nil, rpc.ErrNotFound
 	}
 	return DecodeAddressLookupTableState(account.GetBinary())
 }
@@ -52,7 +52,7 @@ func GetAddressLookupTableStateWithOpts(
 		return nil, err
 	}
 	if account == nil || account.Value == nil {
-		return nil, fmt.Errorf("account not found")
+		return nil, rpc.ErrNotFound
 	}
 	return DecodeAddressLookupTableState(account.GetBinary())
 }

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -142,6 +142,66 @@ func TestClient_GetAccountInfoWithOpts(t *testing.T) {
 	)
 }
 
+func TestClient_GetAccountInfo_NotFound(t *testing.T) {
+	responseBody := `{"context":{"slot":83986105},"value":null}`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	pubkeyString := "7xLk17EQQ5KLDLDe44wCmupJKJjTGd8hs5eSVVhCx932"
+	pubKey := solana.MustPublicKeyFromBase58(pubkeyString)
+	out, err := client.GetAccountInfo(context.Background(), pubKey)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	assert.Equal(t, uint64(83986105), out.RPCContext.Context.Slot)
+	assert.Nil(t, out.Value)
+}
+
+func TestClient_GetAccountInfoWithOpts_NotFound(t *testing.T) {
+	responseBody := `{"context":{"slot":83986105},"value":null}`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	pubkeyString := "7xLk17EQQ5KLDLDe44wCmupJKJjTGd8hs5eSVVhCx932"
+	pubKey := solana.MustPublicKeyFromBase58(pubkeyString)
+	out, err := client.GetAccountInfoWithOpts(
+		context.Background(),
+		pubKey,
+		&GetAccountInfoOpts{},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	assert.Equal(t, uint64(83986105), out.RPCContext.Context.Slot)
+	assert.Nil(t, out.Value)
+}
+
+func TestClient_GetAccountDataInto_NotFound(t *testing.T) {
+	responseBody := `{"context":{"slot":83986105},"value":null}`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	pubkeyString := "7xLk17EQQ5KLDLDe44wCmupJKJjTGd8hs3eSVVhCx932"
+	pubKey := solana.MustPublicKeyFromBase58(pubkeyString)
+	var data struct{}
+	err := client.GetAccountDataInto(context.Background(), pubKey, &data)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestClient_GetAccountDataBorshInto_NotFound(t *testing.T) {
+	responseBody := `{"context":{"slot":83986105},"value":null}`
+	server, closer := mockJSONRPC(t, stdjson.RawMessage(wrapIntoRPC(responseBody)))
+	defer closer()
+	client := New(server.URL)
+
+	pubkeyString := "7xLk17EQQ5KLDLDe44wCmupJKJjTGd8hs3eSVVhCx932"
+	pubKey := solana.MustPublicKeyFromBase58(pubkeyString)
+	var data struct{}
+	err := client.GetAccountDataBorshInto(context.Background(), pubKey, &data)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
 // mustAnyToJSON marshals the provided variable
 // to JSON bytes.
 func mustAnyToJSON(raw any) []byte {

--- a/rpc/getAccountInfo.go
+++ b/rpc/getAccountInfo.go
@@ -43,6 +43,9 @@ func (cl *Client) GetAccountDataInto(ctx context.Context, account solana.PublicK
 	if err != nil {
 		return err
 	}
+	if resp == nil || resp.Value == nil {
+		return ErrNotFound
+	}
 	return bin.NewBinDecoder(resp.Value.Data.GetBinary()).Decode(inVar)
 }
 
@@ -52,6 +55,9 @@ func (cl *Client) GetAccountDataBorshInto(ctx context.Context, account solana.Pu
 	resp, err := cl.GetAccountInfo(ctx, account)
 	if err != nil {
 		return err
+	}
+	if resp == nil || resp.Value == nil {
+		return ErrNotFound
 	}
 	return bin.NewBorshDecoder(resp.Value.Data.GetBinary()).Decode(inVar)
 }
@@ -100,7 +106,7 @@ func (cl *Client) GetAccountInfoWithOpts(
 		return nil, err
 	}
 	if out == nil || out.Value == nil {
-		return nil, ErrNotFound
+		return out, nil
 	}
 	return out, nil
 }


### PR DESCRIPTION
# Fix: align GetAccountInfo with Solana RPC specification for non-existent accounts

## Summary
Per the [Solana JSON-RPC Specification for getAccountInfo](https://solana.com/docs/rpc/http/getaccountinfo), when an account does not exist on-chain, the node returns 
```
{"context": {...}, "value": null}
```
 with no RPC error.

Previously, `GetAccountInfoWithOpts` intercepted `out.Value == nil` and returned `nil, ErrNotFound`. This PR updates `GetAccountInfoWithOpts` to return `(out, nil) (where out.Value == nil)`, matching standard Solana RPC behavior.

## Test

- [x] `go test ./rpc -v -run "TestClient_GetAccount.*"`
- [x] `go vet .`