### PR TITLE
fix(transaction): correct NumWriteableAccounts for resolved v0 messages

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -815,15 +815,12 @@ func countWriteableAccounts(tx *Transaction) (count int) {
 		}
 		return count
 	}
-	numStaticKeys := len(tx.Message.AccountKeys)
+	numStaticKeys := tx.Message.numStaticAccounts()
 	h := tx.Message.Header
 	numSig := int(h.NumRequiredSignatures)
 	numWritableSigned := max(numSig-int(h.NumReadonlySignedAccounts), 0)
 	numWritableUnsigned := max(numStaticKeys-numSig-int(h.NumReadonlyUnsignedAccounts), 0)
 	count += numWritableSigned + numWritableUnsigned
-	if tx.Message.IsResolved() {
-		return count
-	}
 	count += tx.Message.NumWritableLookups()
 	return count
 }

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -884,6 +884,40 @@ func TestTransaction_NumWriteableAccounts_V0(t *testing.T) {
 	assert.Equal(t, 2, tx.NumWriteableAccounts())
 }
 
+// Tests NumWriteableAccounts for a RESOLVED V0 transaction whose lookup table
+// contributes a readonly account: the readonly lookup account must not be
+// counted as writable.
+func TestTransaction_NumWriteableAccounts_V0_Resolved(t *testing.T) {
+	payer := newUniqueKey()
+	programID := newUniqueKey()
+	acctA := newUniqueKey() // writable lookup
+	acctB := newUniqueKey() // readonly lookup
+	tableKey := newUniqueKey()
+
+	tables := map[PublicKey]PublicKeySlice{
+		tableKey: {acctA, acctB},
+	}
+
+	tx, err := NewTransaction(
+		[]Instruction{
+			newTestInstruction(programID, []*AccountMeta{
+				{PublicKey: acctA, IsSigner: false, IsWritable: true},
+				{PublicKey: acctB, IsSigner: false, IsWritable: false},
+			}, []byte{0x01}),
+		},
+		Hash{},
+		TransactionPayer(payer),
+		TransactionAddressTables(tables),
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, tx.Message.ResolveLookups())
+	require.True(t, tx.Message.IsResolved())
+
+	// payer (writable signer) + acctA (writable lookup) = 2; acctB (readonly lookup) must not count
+	assert.Equal(t, 2, tx.NumWriteableAccounts())
+}
+
 // Tests PartialSign with no signer provided doesn't corrupt state.
 func TestPartialSign_NoSignerProvided(t *testing.T) {
 	signer := NewWallet().PrivateKey


### PR DESCRIPTION
## Problem

`(*Transaction).NumWriteableAccounts()` over-counts writable accounts for a resolved v0 message.

`countWriteableAccounts` uses `len(tx.Message.AccountKeys)` as the static-account count and returns early when the message is resolved:

```go
numStaticKeys := len(tx.Message.AccountKeys)
...
count += numWritableSigned + numWritableUnsigned
if tx.Message.IsResolved() {
    return count
}
count += tx.Message.NumWritableLookups()
```

After `Message.ResolveLookups()` (the standard flow after fetching a versioned tx, also done by `addresslookuptable.ResolveMessageLookupsFromRPC`), the lookup accounts are appended to `AccountKeys`, so `len(AccountKeys)` now includes the writable and readonly lookup keys. `numWritableUnsigned = numStaticKeys - numSig - NumReadonlyUnsignedAccounts` subtracts only the static readonly-unsigned count, so every readonly lookup account is counted as writable, and the early return skips `NumWritableLookups()`. The result over-counts writable accounts by the number of readonly lookup accounts (it is only accidentally correct when a resolved message has no readonly lookups).

Concrete case (1 static writable signer + a lookup table contributing one writable and one readonly account):
- Authoritative writable count via `AccountMetaList()`: 2
- `NumWriteableAccounts()` on the resolved message: 3

## Fix

Use `numStaticAccounts()` (which already returns `len(AccountKeys) - NumLookups()` when resolved) and always add `NumWritableLookups()`, so the count is correct in both the resolved and unresolved states.

## Testing

`go test ./ -count=1` passes, including a new regression test `TestTransaction_NumWriteableAccounts_V0_Resolved` for a resolved v0 message with a readonly lookup account (it returns 3 before the change and 2 after). The existing unresolved-path test `TestTransaction_NumWriteableAccounts_V0` is unaffected.
