### PR TITLE
feat(transaction): add V1 transaction format SIMD-0385

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ More contracts to come.
   - [Pretty-Print transactions/instructions](#pretty-print-transactionsinstructions)
   - [SendAndConfirmTransaction](#sendandconfirmtransaction)
   - [Address Lookup Tables](#address-lookup-tables)
+  - [V1 Transactions (SIMD-0385)](#v1-transactions-simd-0385)
   - [Parse/decode an instruction from a transaction](#parsedecode-an-instruction-from-a-transaction)
   - [Borsh encoding/decoding](#borsh-encodingdecoding)
   - [ZSTD account data encoding](#zstd-account-data-encoding)
@@ -56,6 +57,7 @@ More contracts to come.
   - [ ] stake
   - [ ] vote
   - [x] BPF Loader
+  - [x] [compute-budget](/programs/compute-budget) (for [V1 transactions](#v1-transactions-simd-0385) use the inline `solana.TransactionConfig` instead)
   - [ ] Secp256k1
 - [ ] Clients for Solana Program Library (SPL)
   - [x] [SPL token](/programs/token)
@@ -240,6 +242,127 @@ func processTransactionWithAddressLookups(txx *solana.Transaction, rpcClient *rp
 	fmt.Println(txx.String())
 }
 ```
+
+
+## V1 Transactions (SIMD-0385)
+
+V1 is the transaction format introduced by [SIMD-0385](https://github.com/solana-foundation/solana-improvement-documents/pull/385)
+(anza-xyz/solana-sdk [#538](https://github.com/anza-xyz/solana-sdk/pull/538)).
+Compared to legacy/v0 transactions:
+
+| | legacy / v0 | v1 |
+| --- | --- | --- |
+| max transaction size | 1232 bytes | 4096 bytes |
+| compute budget | `ComputeBudget` program instructions | inline `TransactionConfig` in the message header |
+| address lookup tables | v0 only | not supported |
+| max signatures / addresses / instructions | bounded by the 1232-byte size (indices are u8) | 12 / 64 / 64 (enforced by `Sanitize`) |
+| wire layout | `sigs (compact-u16 len) \|\| message` | `0x81 \|\| message \|\| sigs (fixed, no len)` |
+
+The Go API stays the same; you opt in with `solana.TransactionV1Config`
+(or `solana.TransactionMessageVersion(solana.MessageVersionV1)`):
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/programs/system"
+	"github.com/gagliardetto/solana-go/rpc"
+)
+
+func main() {
+	ctx := context.Background()
+	client := rpc.New(rpc.DevNet_RPC)
+
+	sender, _ := solana.PrivateKeyFromSolanaKeygenFile("/path/to/id.json")
+	recipient := solana.NewWallet().PublicKey()
+
+	recent, err := client.GetLatestBlockhash(ctx, rpc.CommitmentFinalized)
+	if err != nil {
+		panic(err)
+	}
+
+	// The compute budget lives in the message header; every field is optional.
+	config := solana.TransactionConfig{}.
+		WithComputeUnitLimit(20_000). // unset means 0 CUs -> always set it
+		WithPriorityFee(1_000)        // TOTAL lamports, not micro-lamports/CU
+	// Also available: WithLoadedAccountsDataSizeLimit(bytes), WithHeapSize(bytes)
+	// (heap must be a multiple of 1024 within [32 KiB, 256 KiB]).
+
+	tx, err := solana.NewTransaction(
+		[]solana.Instruction{
+			system.NewTransferInstruction(solana.LAMPORTS_PER_SOL/1000, sender.PublicKey(), recipient).Build(),
+		},
+		recent.Value.Blockhash,
+		solana.TransactionPayer(sender.PublicKey()),
+		solana.TransactionV1Config(config), // <- selects the V1 format
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	// Signing, sending and confirming are unchanged.
+	if _, err := tx.Sign(func(key solana.PublicKey) *solana.PrivateKey {
+		if sender.PublicKey().Equals(key) {
+			return &sender
+		}
+		return nil
+	}); err != nil {
+		panic(err)
+	}
+	sig, err := client.SendTransaction(ctx, tx)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(sig)
+}
+```
+
+Decoding is automatic (`TransactionFromBytes`, `TransactionFromBase64`,
+`rpc` results, JSON): the version byte `0x81` selects the V1 decoder.
+
+```go
+tx, err := solana.TransactionFromBase64(b64)
+if err != nil {
+	panic(err)
+}
+if tx.Message.GetVersion() == solana.MessageVersionV1 {
+	cfg := tx.Message.TransactionConfig // *uint64 / *uint32 fields, nil = not requested
+	if cfg.ComputeUnitLimit != nil {
+		fmt.Println("compute unit limit:", *cfg.ComputeUnitLimit)
+	}
+}
+if err := tx.Sanitize(); err != nil { // structural limits; the 4096-byte cap is enforced by the cluster
+	panic(err)
+}
+```
+
+When fetching transactions/blocks from the RPC, ask for version 1
+(`getTransaction`, `getBlock`, `blockSubscribe`, ... all take the same option):
+
+```go
+out, err := client.GetTransaction(ctx, sig, &rpc.GetTransactionOpts{
+	MaxSupportedTransactionVersion: &rpc.MaxSupportedTransactionVersion1,
+})
+```
+
+Things to keep in mind:
+
+- The cluster must have SIMD-0385 activated, otherwise V1 transactions are
+  rejected during sanitization.
+- `PriorityFee` is the total priority fee in lamports for the whole
+  transaction (unlike `SetComputeUnitPrice`, which is micro-lamports per CU).
+- An unset `ComputeUnitLimit` means a requested limit of 0 compute units.
+- `ComputeBudget` program instructions are no-ops in V1 transactions; `NewTransaction` rejects them for V1.
+- V1 transactions cannot use address lookup tables; combining
+  `TransactionV1Config` with `TransactionAddressTables` is an error.
+- `solana.MaxTransactionSizeV1` (4096) is the size cap including signatures (checked by the cluster, not the SDK).
+
+See [rpc/examples/sendTransactionV1](/rpc/examples/sendTransactionV1) and the
+`ExampleNewTransaction_v1` godoc example for complete programs.
 
 
 ## Parse/decode an instruction from a transaction

--- a/example_v1_test.go
+++ b/example_v1_test.go
@@ -1,0 +1,75 @@
+package solana_test
+
+import (
+	"crypto/ed25519"
+	"fmt"
+
+	"github.com/gagliardetto/solana-go"
+)
+
+// ExampleNewTransaction_v1 builds, signs, serializes and decodes a V1
+// (SIMD-0385) transaction with an inline compute budget configuration.
+func ExampleNewTransaction_v1() {
+	// Deterministic keys for the example; use solana.NewWallet() in real code.
+	payerKey := solana.PrivateKey(ed25519.NewKeyFromSeed(make([]byte, 32)))
+	payer := payerKey.PublicKey()
+	recipient := solana.MustPublicKeyFromBase58("2mHtsPqiHkQKKh6t2Q1jGwYQ8vG7ULfF7c9k4t9BvGkw")
+	programID := solana.SystemProgramID
+
+	// Any Instruction works; this is a raw System Program transfer of 1 lamport.
+	data := []byte{2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0}
+	ix := solana.NewInstruction(programID, solana.AccountMetaSlice{
+		solana.Meta(payer).WRITE().SIGNER(),
+		solana.Meta(recipient).WRITE(),
+	}, data)
+
+	// A zero blockhash for the example; fetch it from the RPC in real code.
+	var blockhash solana.Hash
+
+	tx, err := solana.NewTransaction(
+		[]solana.Instruction{ix},
+		blockhash,
+		solana.TransactionPayer(payer),
+		// Selects v1; unset CU limit means 0, PriorityFee is total lamports.
+		solana.TransactionV1Config(solana.TransactionConfig{}.
+			WithComputeUnitLimit(20_000).
+			WithPriorityFee(1_000)),
+	)
+	if err != nil {
+		panic(err)
+	}
+	if _, err := tx.Sign(func(key solana.PublicKey) *solana.PrivateKey {
+		if key.Equals(payer) {
+			return &payerKey
+		}
+		return nil
+	}); err != nil {
+		panic(err)
+	}
+
+	// Wire: 0x81 prefix first, signatures last (no length prefix).
+	wire, err := tx.MarshalBinary()
+	if err != nil {
+		panic(err)
+	}
+
+	decoded, err := solana.TransactionFromBytes(wire)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("version:", decoded.Message.GetVersion() == solana.MessageVersionV1)
+	fmt.Println("prefix: 0x" + fmt.Sprintf("%02x", wire[0]))
+	fmt.Println("compute unit limit:", *decoded.Message.TransactionConfig.ComputeUnitLimit)
+	fmt.Println("priority fee:", *decoded.Message.TransactionConfig.PriorityFee)
+	fmt.Println("heap size requested:", decoded.Message.TransactionConfig.HeapSize != nil)
+	fmt.Println("size ok:", len(wire) <= solana.MaxTransactionSizeV1)
+	fmt.Println("signatures valid:", decoded.VerifySignatures() == nil)
+	// Output:
+	// version: true
+	// prefix: 0x81
+	// compute unit limit: 20000
+	// priority fee: 1000
+	// heap size requested: false
+	// size ok: true
+	// signatures valid: true
+}

--- a/message.go
+++ b/message.go
@@ -100,12 +100,11 @@ type MessageVersion int
 const (
 	MessageVersionLegacy MessageVersion = 0 // default
 	MessageVersionV0     MessageVersion = 1 // v0
+	MessageVersionV1     MessageVersion = 2 // v1 (SIMD-0385)
 )
 
-// messageVersionPrefix is the high bit mask used to indicate a versioned message.
-// If the first byte has this bit set, the message is versioned; the remaining
-// 7 bits encode the version number (0 for V0, 1 for V1, etc.).
-// See: https://github.com/anza-xyz/solana-sdk/blob/master/message/src/versions/mod.rs
+// messageVersionPrefix marks a versioned message; low 7 bits are the version.
+// The Go enum is offset by one (V0=1 -> 0x80, V1=2 -> 0x81).
 const messageVersionPrefix = 0x80
 
 type Message struct {
@@ -126,8 +125,11 @@ type Message struct {
 	// and committed in one atomic transaction if all succeed.
 	Instructions []CompiledInstruction `json:"instructions"`
 
-	// List of address table lookups used to load additional accounts for this transaction.
+	// List of address table lookups used to load additional accounts for this transaction (v0 only).
 	AddressTableLookups MessageAddressTableLookupSlice `json:"addressTableLookups"`
+
+	// Inline compute budget (v1 only, SIMD-0385).
+	TransactionConfig TransactionConfig `json:"transactionConfig"`
 
 	// The actual tables that contain the list of account pubkeys.
 	// NOTE: you need to fetch these from the chain, and then call `SetAddressTables`
@@ -156,13 +158,19 @@ func (mx *Message) GetAddressTables() map[PublicKey]PublicKeySlice {
 
 var _ bin.EncoderDecoder = &Message{}
 
-// SetVersion sets the message version.
-// This method forces the message to be encoded in the specified version.
-// NOTE: if you set lookups, the version will default to V0.
+// SetVersion forces the encoding version.
+// V1 cannot carry lookups; leaving V1 with a non-empty config is an error.
 func (m *Message) SetVersion(version MessageVersion) (*Message, error) {
 	// check if the version is valid
 	switch version {
 	case MessageVersionV0, MessageVersionLegacy:
+		if !m.TransactionConfig.IsEmpty() {
+			return nil, fmt.Errorf("message has a TransactionConfig, which only v1 encodes; clear it before setting version %d", version)
+		}
+	case MessageVersionV1:
+		if len(m.AddressTableLookups) > 0 {
+			return nil, fmt.Errorf("v1 messages do not support address table lookups (got %d)", len(m.AddressTableLookups))
+		}
 	default:
 		return nil, fmt.Errorf("invalid message version: %d", version)
 	}
@@ -175,17 +183,21 @@ func (m *Message) GetVersion() MessageVersion {
 	return m.version
 }
 
-// SetAddressTableLookups (re)sets the lookups used by this message.
+// SetAddressTableLookups (re)sets the lookups; legacy becomes v0, v1 is kept.
 func (mx *Message) SetAddressTableLookups(lookups []MessageAddressTableLookup) *Message {
 	mx.AddressTableLookups = lookups
-	mx.version = MessageVersionV0
+	if mx.version != MessageVersionV1 {
+		mx.version = MessageVersionV0
+	}
 	return mx
 }
 
-// AddAddressTableLookup adds a new lookup to the message.
+// AddAddressTableLookup adds a lookup; legacy becomes v0, v1 is kept.
 func (mx *Message) AddAddressTableLookup(lookup MessageAddressTableLookup) *Message {
 	mx.AddressTableLookups = append(mx.AddressTableLookups, lookup)
-	mx.version = MessageVersionV0
+	if mx.version != MessageVersionV1 {
+		mx.version = MessageVersionV0
+	}
 	return mx
 }
 
@@ -223,6 +235,23 @@ func (mx Message) MarshalJSON() ([]byte, error) {
 		}
 		return json.Marshal(out)
 	}
+	if mx.version == MessageVersionV1 {
+		// V1: RPC (agave UiRawMessage) shape, `transactionConfig` and no lookups.
+		out := struct {
+			AccountKeys       PublicKeySlice        `json:"accountKeys"`
+			Header            MessageHeader         `json:"header"`
+			RecentBlockhash   Hash                  `json:"recentBlockhash"`
+			Instructions      []CompiledInstruction `json:"instructions"`
+			TransactionConfig TransactionConfig     `json:"transactionConfig"`
+		}{
+			AccountKeys:       mx.AccountKeys,
+			Header:            mx.Header,
+			RecentBlockhash:   mx.RecentBlockhash,
+			Instructions:      mx.Instructions,
+			TransactionConfig: mx.TransactionConfig,
+		}
+		return json.Marshal(out)
+	}
 	// Versioned message:
 	lookups := mx.AddressTableLookups
 	if lookups == nil {
@@ -244,20 +273,16 @@ func (mx Message) MarshalJSON() ([]byte, error) {
 	return json.Marshal(out)
 }
 
-// UnmarshalJSON decodes the message from JSON and determines its version.
-// The Solana RPC emits `addressTableLookups` only for versioned (V0+)
-// messages; its presence in the JSON is what distinguishes V0 from legacy,
-// since the private `version` field has no wire representation.
+// UnmarshalJSON decodes the message; `addressTableLookups` selects v0, `transactionConfig` v1.
 func (mx *Message) UnmarshalJSON(data []byte) error {
-	// Decode `addressTableLookups` via a RawMessage pointer so presence of the
-	// key can be detected in a single parse. A non-nil pointer means the key
-	// was present in the JSON (even if its value is `null`), which selects V0.
+	// RawMessage pointers detect key presence (non-nil = present, non-null).
 	aux := struct {
 		AccountKeys         PublicKeySlice        `json:"accountKeys"`
 		Header              MessageHeader         `json:"header"`
 		RecentBlockhash     Hash                  `json:"recentBlockhash"`
 		Instructions        []CompiledInstruction `json:"instructions"`
 		AddressTableLookups *gojson.RawMessage    `json:"addressTableLookups"`
+		TransactionConfig   *gojson.RawMessage    `json:"transactionConfig"`
 	}{}
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
@@ -266,6 +291,16 @@ func (mx *Message) UnmarshalJSON(data []byte) error {
 	mx.Header = aux.Header
 	mx.RecentBlockhash = aux.RecentBlockhash
 	mx.Instructions = aux.Instructions
+	mx.TransactionConfig = TransactionConfig{}
+
+	if aux.TransactionConfig != nil {
+		if aux.AddressTableLookups != nil && string(*aux.AddressTableLookups) != "[]" {
+			return fmt.Errorf("message JSON has both transactionConfig (v1) and addressTableLookups (v0)")
+		}
+		mx.version = MessageVersionV1
+		mx.AddressTableLookups = nil
+		return json.Unmarshal(*aux.TransactionConfig, &mx.TransactionConfig)
+	}
 
 	if aux.AddressTableLookups == nil {
 		mx.version = MessageVersionLegacy
@@ -280,12 +315,20 @@ func (mx *Message) EncodeToTree(txTree treeout.Branches) {
 	switch mx.version {
 	case MessageVersionV0:
 		txTree.Child("Version: v0")
+	case MessageVersionV1:
+		txTree.Child("Version: v1")
 	case MessageVersionLegacy:
 		txTree.Child("Version: legacy")
 	default:
 		txTree.Child(text.Sf("Version (unknown): %v", mx.version))
 	}
 	txTree.Child(text.Sf("RecentBlockhash: %s", mx.RecentBlockhash))
+
+	if mx.version == MessageVersionV1 {
+		txTree.Child("TransactionConfig").ParentFunc(func(cfgBranch treeout.Branches) {
+			mx.TransactionConfig.EncodeToTree(cfgBranch)
+		})
+	}
 
 	txTree.Child(fmt.Sprintf("AccountKeys[len=%v]", mx.numStaticAccounts()+mx.AddressTableLookups.NumLookups())).ParentFunc(func(accountKeysBranch treeout.Branches) {
 		accountKeys, err := mx.AccountMetaList()
@@ -303,7 +346,7 @@ func (mx *Message) EncodeToTree(txTree treeout.Branches) {
 		}
 	})
 
-	if mx.IsVersioned() {
+	if mx.version == MessageVersionV0 {
 		txTree.Child(fmt.Sprintf("AddressTableLookups[len=%v]", len(mx.AddressTableLookups))).ParentFunc(func(lookupsBranch treeout.Branches) {
 			for _, lookup := range mx.AddressTableLookups {
 				lookupsBranch.Child(text.Sf("%s", text.ColorizeBG(lookup.AccountKey.String()))).ParentFunc(func(lookupBranch treeout.Branches) {
@@ -325,10 +368,27 @@ func (header *MessageHeader) EncodeToTree(mxBranch treeout.Branches) {
 	mxBranch.Child(text.Sf("NumReadonlyUnsignedAccounts: %v", header.NumReadonlyUnsignedAccounts))
 }
 
+// EncodeToTree renders the config; unset fields are shown as "<unset>".
+func (c *TransactionConfig) EncodeToTree(branch treeout.Branches) {
+	branch.Child(text.Sf("PriorityFee: %s", fmtOptional(c.PriorityFee)))
+	branch.Child(text.Sf("ComputeUnitLimit: %s", fmtOptional(c.ComputeUnitLimit)))
+	branch.Child(text.Sf("LoadedAccountsDataSizeLimit: %s", fmtOptional(c.LoadedAccountsDataSizeLimit)))
+	branch.Child(text.Sf("HeapSize: %s", fmtOptional(c.HeapSize)))
+}
+
+func fmtOptional[T uint32 | uint64](v *T) string {
+	if v == nil {
+		return "<unset>"
+	}
+	return fmt.Sprintf("%d", *v)
+}
+
 func (mx *Message) MarshalBinary() ([]byte, error) {
 	switch mx.version {
 	case MessageVersionV0:
 		return mx.MarshalV0()
+	case MessageVersionV1:
+		return mx.MarshalV1()
 	case MessageVersionLegacy:
 		return mx.MarshalLegacy()
 	default:
@@ -372,13 +432,11 @@ func (mx *Message) MarshalLegacy() ([]byte, error) {
 }
 
 func (mx *Message) MarshalV0() ([]byte, error) {
-	// The actual Solana version number is the Go enum value minus 1
-	// (MessageVersionV0=1 maps to Solana version 0).
-	// The wire prefix is messageVersionPrefix (0x80) OR'd with the version number.
-	solanaVersion := byte(mx.version - 1)
-	if solanaVersion > 0x7F {
-		return nil, fmt.Errorf("invalid message version: %d", mx.version)
+	if mx.version == MessageVersionV1 {
+		return nil, fmt.Errorf("cannot encode a v1 message as v0; use MarshalV1")
 	}
+	// Wire prefix: messageVersionPrefix (0x80) | version 0.
+	const solanaVersion = byte(0)
 
 	staticAccountKeys := mx.getStaticKeys()
 
@@ -451,21 +509,25 @@ func (mx Message) ToBase64() string {
 }
 
 func (mx *Message) UnmarshalWithDecoder(decoder *bin.Decoder) (err error) {
-	// peek first byte to determine if this is a legacy or v0 message
+	// peek first byte to determine if this is a legacy, v0 or v1 message
 	versionNum, err := decoder.Peek(1)
 	if err != nil {
 		return err
 	}
-	// If the high bit (0x80) is set, this is a versioned message;
-	// otherwise it is a legacy message where this byte is numRequiredSignatures.
-	if versionNum[0]&messageVersionPrefix == 0 {
+	// High bit set = versioned (0x81 = v1, else v0); otherwise legacy.
+	switch {
+	case versionNum[0]&messageVersionPrefix == 0:
 		mx.version = MessageVersionLegacy
-	} else {
+	case versionNum[0] == messageVersionV1Prefix:
+		mx.version = MessageVersionV1
+	default:
 		mx.version = MessageVersionV0
 	}
 	switch mx.version {
 	case MessageVersionV0:
 		return mx.UnmarshalV0(decoder)
+	case MessageVersionV1:
+		return mx.UnmarshalV1(decoder)
 	case MessageVersionLegacy:
 		return mx.UnmarshalLegacy(decoder)
 	default:
@@ -643,6 +705,9 @@ func (mx *Message) UnmarshalV0(decoder *bin.Decoder) (err error) {
 }
 
 func (mx *Message) UnmarshalLegacy(decoder *bin.Decoder) (err error) {
+	// Reset fields not present in this format (the receiver may be reused).
+	mx.AddressTableLookups = nil
+	mx.TransactionConfig = TransactionConfig{}
 	{
 		mx.Header.NumRequiredSignatures, err = decoder.ReadUint8()
 		if err != nil {
@@ -770,6 +835,7 @@ func (m *Message) AccountMetaList() (AccountMetaSlice, error) {
 	return out, nil
 }
 
+// IsVersioned reports whether the message is v0 or v1 (not legacy).
 func (m *Message) IsVersioned() bool {
 	return m.version != MessageVersionLegacy
 }
@@ -964,7 +1030,7 @@ func (m *Message) uncheckedAccountIndexIsWritable(index int) bool {
 }
 
 func (m *Message) signerKeys() PublicKeySlice {
-	return m.AccountKeys[0:m.Header.NumRequiredSignatures]
+	return m.AccountKeys[:min(int(m.Header.NumRequiredSignatures), len(m.AccountKeys))]
 }
 
 // ProgramIDs returns the deduplicated list of program IDs used by the message's instructions.

--- a/message_bench_test.go
+++ b/message_bench_test.go
@@ -2,6 +2,8 @@ package solana
 
 import (
 	"testing"
+
+	bin "github.com/gagliardetto/binary"
 )
 
 // helpers to build realistic messages for benchmarking.
@@ -200,6 +202,38 @@ func BenchmarkMessage_MarshalBinary_V0(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, _ = msg.MarshalBinary()
+	}
+}
+
+func buildV1Message() Message {
+	msg := buildLegacyMessage()
+	msg.version = MessageVersionV1
+	msg.TransactionConfig = TransactionConfig{}.
+		WithComputeUnitLimit(200_000).
+		WithPriorityFee(5_000)
+	return msg
+}
+
+func BenchmarkMessage_MarshalBinary_V1(b *testing.B) {
+	msg := buildV1Message()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = msg.MarshalBinary()
+	}
+}
+
+func BenchmarkMessage_UnmarshalBinary_V1(b *testing.B) {
+	msg := buildV1Message()
+	data, err := msg.MarshalBinary()
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var out Message
+		if err := out.UnmarshalWithDecoder(bin.NewBinDecoder(data)); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 

--- a/message_test.go
+++ b/message_test.go
@@ -173,11 +173,12 @@ func TestVersionDetection_PrefixByte(t *testing.T) {
 	}
 }
 
-// Tests that unsupported version numbers (> 0) in versioned messages are rejected.
+// Tests that unsupported version numbers (> 1) in versioned messages are rejected.
 // Ported from solana-sdk/message/src/versions/v0/mod.rs version validation.
+// (0x81 is V1 since SIMD-0385; see TestVersionDetection_V1PrefixByte.)
 func TestVersionDetection_UnsupportedVersion(t *testing.T) {
-	// 0x81 = messageVersionPrefix | 1 -> version 1 (unsupported)
-	buf := []byte{0x81, 1, 0, 0}
+	// 0x82 = messageVersionPrefix | 2 -> version 2 (unsupported)
+	buf := []byte{0x82, 1, 0, 0}
 	buf = append(buf, 1)                   // 1 account key
 	buf = append(buf, make([]byte, 32)...) // account key
 	buf = append(buf, make([]byte, 32)...) // blockhash
@@ -188,6 +189,25 @@ func TestVersionDetection_UnsupportedVersion(t *testing.T) {
 	err := msg.UnmarshalWithDecoder(bin.NewBinDecoder(buf))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported message version")
+}
+
+// Tests that 0x81 routes to the V1 decoder (SIMD-0385).
+func TestVersionDetection_V1PrefixByte(t *testing.T) {
+	// v1: prefix(1) + header(3) + mask(4) + blockhash(32) + num_ix(1) + num_addr(1) + key(32)
+	buf := []byte{0x81, 1, 0, 0}
+	buf = append(buf, 0, 0, 0, 0)          // config mask = 0
+	buf = append(buf, make([]byte, 32)...) // lifetime specifier
+	buf = append(buf, 0)                   // 0 instructions
+	buf = append(buf, 1)                   // 1 address
+	buf = append(buf, make([]byte, 32)...) // address
+
+	var msg Message
+	err := msg.UnmarshalWithDecoder(bin.NewBinDecoder(buf))
+	require.NoError(t, err)
+	assert.Equal(t, MessageVersionV1, msg.GetVersion())
+	assert.True(t, msg.IsVersioned())
+	assert.Len(t, msg.AccountKeys, 1)
+	assert.True(t, msg.TransactionConfig.IsEmpty())
 }
 
 // Ported from solana-sdk/message/src/legacy.rs: test_is_writable_index_saturating_behavior.
@@ -474,6 +494,11 @@ func TestMarshalV0_PrefixByte(t *testing.T) {
 
 	// Second byte should be numRequiredSignatures.
 	assert.Equal(t, byte(1), data[1])
+
+	// MarshalV0 refuses v1 messages (they would lose the inline config).
+	msg.version = MessageVersionV1
+	_, err = msg.MarshalV0()
+	require.Error(t, err)
 }
 
 // Tests that legacy message does NOT have the 0x80 prefix.
@@ -639,8 +664,20 @@ func TestSetVersion_Validation(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, MessageVersionV0, msg.GetVersion())
 
+	_, err = msg.SetVersion(MessageVersionV1)
+	require.NoError(t, err)
+	assert.Equal(t, MessageVersionV1, msg.GetVersion())
+
 	_, err = msg.SetVersion(MessageVersion(99))
 	require.Error(t, err)
+
+	// V1 cannot carry address table lookups.
+	withLookups := &Message{}
+	withLookups.AddAddressTableLookup(MessageAddressTableLookup{AccountKey: newUniqueKey(), WritableIndexes: []uint8{0}})
+	assert.Equal(t, MessageVersionV0, withLookups.GetVersion())
+	_, err = withLookups.SetVersion(MessageVersionV1)
+	require.Error(t, err)
+	assert.Equal(t, MessageVersionV0, withLookups.GetVersion())
 }
 
 // Tests IsVersioned().
@@ -650,6 +687,9 @@ func TestIsVersioned(t *testing.T) {
 	assert.False(t, msg.IsVersioned())
 
 	msg.version = MessageVersionV0
+	assert.True(t, msg.IsVersioned())
+
+	msg.version = MessageVersionV1
 	assert.True(t, msg.IsVersioned())
 }
 
@@ -1283,6 +1323,7 @@ func TestMessageJSONVersionRoundtrip(t *testing.T) {
 		{"v0_with_lookups", MessageVersionV0, MessageAddressTableLookupSlice{
 			{AccountKey: newUniqueKey(), WritableIndexes: []uint8{0, 1}, ReadonlyIndexes: []uint8{2}},
 		}},
+		{"v1", MessageVersionV1, nil},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			original := Message{

--- a/message_v1.go
+++ b/message_v1.go
@@ -1,0 +1,406 @@
+// Copyright 2026 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package solana
+
+// V1 message format (SIMD-0385); ported from solana-sdk message/src/versions/v1.
+//
+// Signed message bytes:
+//
+//	0x81 | header(3) | mask(u32 LE) | lifetime(32) | num_ix(u8) | num_addr(u8)
+//	| addresses | config values | ix headers (u8,u8,u16 LE) | ix payloads
+//
+// Transaction = message || fixed 64-byte signatures (no length prefix).
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	bin "github.com/gagliardetto/binary"
+)
+
+// messageVersionV1Prefix is the first byte of a V1 message (0x81).
+const messageVersionV1Prefix byte = messageVersionPrefix | 1
+
+const (
+	// MaxTransactionSizeV1 is the V1 size cap, signatures included (enforced by the cluster).
+	MaxTransactionSizeV1 = 4096
+	// MaxAddressesV1 is the maximum number of addresses in a V1 message.
+	MaxAddressesV1 = 64
+	// MaxInstructionsV1 is the maximum number of instructions in a V1 message.
+	MaxInstructionsV1 = 64
+	// MaxSignaturesV1 is the maximum number of signatures in a V1 transaction.
+	MaxSignaturesV1 = 12
+	// MinHeapSizeV1 is the minimum (and default) requested heap size.
+	MinHeapSizeV1 uint32 = 32 * 1024
+	// MaxHeapSizeV1 is the maximum requested heap size.
+	MaxHeapSizeV1 uint32 = 256 * 1024
+	// DefaultHeapSizeV1 is the heap size when none is requested.
+	DefaultHeapSizeV1 = MinHeapSizeV1
+
+	// fixedHeaderSizeV1: header(3)+mask(4)+lifetime(32)+num_ix(1)+num_addr(1), excludes prefix.
+	fixedHeaderSizeV1 = 3 + 4 + 32 + 1 + 1
+	// instructionHeaderSizeV1: program_id_index(1)+num_accounts(1)+data_len(2).
+	instructionHeaderSizeV1 = 1 + 1 + 2
+)
+
+// TransactionConfig is the v1 inline compute budget; nil field = not requested.
+// Unset ComputeUnitLimit means 0 CUs; PriorityFee is total lamports.
+type TransactionConfig struct {
+	// Total priority fee in lamports.
+	PriorityFee *uint64 `json:"priorityFee"`
+	// Maximum compute units; nil means 0.
+	ComputeUnitLimit *uint32 `json:"computeUnitLimit"`
+	// Maximum bytes of loaded account data; nil means 0.
+	LoadedAccountsDataSizeLimit *uint32 `json:"loadedAccountsDataSizeLimit"`
+	// Heap size: multiple of 1024 in [MinHeapSizeV1, MaxHeapSizeV1]; nil means default.
+	HeapSize *uint32 `json:"heapSize"`
+}
+
+// WithPriorityFee returns a copy with the priority fee (total lamports) set.
+func (c TransactionConfig) WithPriorityFee(lamports uint64) TransactionConfig {
+	c.PriorityFee = &lamports
+	return c
+}
+
+// WithComputeUnitLimit returns a copy with the compute unit limit set.
+func (c TransactionConfig) WithComputeUnitLimit(units uint32) TransactionConfig {
+	c.ComputeUnitLimit = &units
+	return c
+}
+
+// WithLoadedAccountsDataSizeLimit returns a copy with the loaded accounts data size limit set.
+func (c TransactionConfig) WithLoadedAccountsDataSizeLimit(bytes uint32) TransactionConfig {
+	c.LoadedAccountsDataSizeLimit = &bytes
+	return c
+}
+
+// WithHeapSize returns a copy with the heap size set (validated by Sanitize).
+func (c TransactionConfig) WithHeapSize(bytes uint32) TransactionConfig {
+	c.HeapSize = &bytes
+	return c
+}
+
+// IsEmpty reports whether no config value is set.
+func (c TransactionConfig) IsEmpty() bool {
+	return c.Mask() == 0
+}
+
+// Size returns the encoded size of the config values in bytes.
+func (c TransactionConfig) Size() int {
+	return c.Mask().SizeOfConfig()
+}
+
+// Mask returns the TransactionConfigMask describing which values are set.
+func (c TransactionConfig) Mask() TransactionConfigMask {
+	var mask TransactionConfigMask
+	if c.PriorityFee != nil {
+		mask |= TransactionConfigMaskPriorityFee
+	}
+	if c.ComputeUnitLimit != nil {
+		mask |= TransactionConfigMaskComputeUnitLimit
+	}
+	if c.LoadedAccountsDataSizeLimit != nil {
+		mask |= TransactionConfigMaskLoadedAccountsDataSize
+	}
+	if c.HeapSize != nil {
+		mask |= TransactionConfigMaskHeapSize
+	}
+	return mask
+}
+
+// TransactionConfigMask flags which config values a V1 message carries.
+type TransactionConfigMask uint32
+
+const (
+	// TransactionConfigMaskPriorityFee: bits 0-1 (both required), u64 LE.
+	TransactionConfigMaskPriorityFee TransactionConfigMask = 0b11
+	// TransactionConfigMaskComputeUnitLimit: bit 2, u32 LE.
+	TransactionConfigMaskComputeUnitLimit TransactionConfigMask = 0b100
+	// TransactionConfigMaskLoadedAccountsDataSize: bit 3, u32 LE.
+	TransactionConfigMaskLoadedAccountsDataSize TransactionConfigMask = 0b1000
+	// TransactionConfigMaskHeapSize: bit 4, u32 LE.
+	TransactionConfigMaskHeapSize TransactionConfigMask = 0b10000
+	// TransactionConfigMaskKnownBits is the union of all supported bits.
+	TransactionConfigMaskKnownBits = TransactionConfigMaskPriorityFee |
+		TransactionConfigMaskComputeUnitLimit |
+		TransactionConfigMaskLoadedAccountsDataSize |
+		TransactionConfigMaskHeapSize
+)
+
+// HasUnknownBits reports whether any unsupported bit is set.
+func (m TransactionConfigMask) HasUnknownBits() bool {
+	return (m | TransactionConfigMaskKnownBits) != TransactionConfigMaskKnownBits
+}
+
+// HasPriorityFee reports whether both priority fee bits are set.
+func (m TransactionConfigMask) HasPriorityFee() bool {
+	return (m & TransactionConfigMaskPriorityFee) == TransactionConfigMaskPriorityFee
+}
+
+// HasInvalidPriorityFeeBits reports whether exactly one priority fee bit is set.
+func (m TransactionConfigMask) HasInvalidPriorityFeeBits() bool {
+	bits := m & TransactionConfigMaskPriorityFee
+	return bits != 0 && bits != TransactionConfigMaskPriorityFee
+}
+
+// HasComputeUnitLimit reports whether the compute unit limit bit is set.
+func (m TransactionConfigMask) HasComputeUnitLimit() bool {
+	return (m & TransactionConfigMaskComputeUnitLimit) != 0
+}
+
+// HasLoadedAccountsDataSize reports whether the loaded accounts data size bit is set.
+func (m TransactionConfigMask) HasLoadedAccountsDataSize() bool {
+	return (m & TransactionConfigMaskLoadedAccountsDataSize) != 0
+}
+
+// HasHeapSize reports whether the heap size bit is set.
+func (m TransactionConfigMask) HasHeapSize() bool {
+	return (m & TransactionConfigMaskHeapSize) != 0
+}
+
+// SizeOfConfig returns the encoded size of the flagged config values.
+func (m TransactionConfigMask) SizeOfConfig() int {
+	size := 0
+	if m.HasPriorityFee() {
+		size += 8
+	}
+	if m.HasComputeUnitLimit() {
+		size += 4
+	}
+	if m.HasLoadedAccountsDataSize() {
+		size += 4
+	}
+	if m.HasHeapSize() {
+		size += 4
+	}
+	return size
+}
+
+// sizeV1 returns the V1 encoded size, version byte included.
+func (mx *Message) sizeV1() int {
+	size := 1 + fixedHeaderSizeV1 +
+		32*len(mx.AccountKeys) +
+		mx.TransactionConfig.Size() +
+		instructionHeaderSizeV1*len(mx.Instructions)
+	for i := range mx.Instructions {
+		size += len(mx.Instructions[i].Accounts) + len(mx.Instructions[i].Data)
+	}
+	return size
+}
+
+// MarshalV1 encodes the message as v1 (0x81 prefix included); never truncates.
+func (mx *Message) MarshalV1() ([]byte, error) {
+	if len(mx.AddressTableLookups) > 0 {
+		return nil, fmt.Errorf("v1 messages do not support address table lookups (got %d)", len(mx.AddressTableLookups))
+	}
+	if len(mx.AccountKeys) > 255 {
+		return nil, fmt.Errorf("v1 message: too many account keys (%d), max 255", len(mx.AccountKeys))
+	}
+	if len(mx.Instructions) > 255 {
+		return nil, fmt.Errorf("v1 message: too many instructions (%d), max 255", len(mx.Instructions))
+	}
+	for i := range mx.Instructions {
+		ix := &mx.Instructions[i]
+		if ix.ProgramIDIndex > 255 {
+			return nil, fmt.Errorf("v1 message: instruction %d: program_id_index %d does not fit in a byte", i, ix.ProgramIDIndex)
+		}
+		if len(ix.Accounts) > 255 {
+			return nil, fmt.Errorf("v1 message: instruction %d: too many accounts (%d), max 255", i, len(ix.Accounts))
+		}
+		if len(ix.Data) > 65535 {
+			return nil, fmt.Errorf("v1 message: instruction %d: data too large (%d bytes), max 65535", i, len(ix.Data))
+		}
+		for j, idx := range ix.Accounts {
+			if idx > 255 {
+				return nil, fmt.Errorf("v1 message: instruction %d: account index %d (%d) does not fit in a byte", i, j, idx)
+			}
+		}
+	}
+
+	buf := make([]byte, 0, mx.sizeV1())
+	buf = append(buf, messageVersionV1Prefix,
+		mx.Header.NumRequiredSignatures,
+		mx.Header.NumReadonlySignedAccounts,
+		mx.Header.NumReadonlyUnsignedAccounts,
+	)
+	buf = binary.LittleEndian.AppendUint32(buf, uint32(mx.TransactionConfig.Mask()))
+	buf = append(buf, mx.RecentBlockhash[:]...)
+	buf = append(buf, byte(len(mx.Instructions)), byte(len(mx.AccountKeys)))
+	for i := range mx.AccountKeys {
+		buf = append(buf, mx.AccountKeys[i][:]...)
+	}
+
+	cfg := &mx.TransactionConfig
+	if cfg.PriorityFee != nil {
+		buf = binary.LittleEndian.AppendUint64(buf, *cfg.PriorityFee)
+	}
+	if cfg.ComputeUnitLimit != nil {
+		buf = binary.LittleEndian.AppendUint32(buf, *cfg.ComputeUnitLimit)
+	}
+	if cfg.LoadedAccountsDataSizeLimit != nil {
+		buf = binary.LittleEndian.AppendUint32(buf, *cfg.LoadedAccountsDataSizeLimit)
+	}
+	if cfg.HeapSize != nil {
+		buf = binary.LittleEndian.AppendUint32(buf, *cfg.HeapSize)
+	}
+
+	for i := range mx.Instructions {
+		ix := &mx.Instructions[i]
+		buf = append(buf, byte(ix.ProgramIDIndex), byte(len(ix.Accounts)))
+		buf = binary.LittleEndian.AppendUint16(buf, uint16(len(ix.Data)))
+	}
+	for i := range mx.Instructions {
+		ix := &mx.Instructions[i]
+		for _, idx := range ix.Accounts {
+			buf = append(buf, byte(idx))
+		}
+		buf = append(buf, ix.Data...)
+	}
+	return buf, nil
+}
+
+// UnmarshalV1 decodes a v1 message from the 0x81 prefix; limits are checked by Sanitize.
+func (mx *Message) UnmarshalV1(decoder *bin.Decoder) (err error) {
+	prefix, err := decoder.ReadByte()
+	if err != nil {
+		return fmt.Errorf("failed to read message version prefix: %w", err)
+	}
+	if prefix != messageVersionV1Prefix {
+		return fmt.Errorf("invalid v1 message version prefix: expected 0x%02x, got 0x%02x", messageVersionV1Prefix, prefix)
+	}
+	mx.version = MessageVersionV1
+	mx.AddressTableLookups = nil
+	mx.addressTables = nil
+	mx.resolved = false
+	mx.TransactionConfig = TransactionConfig{}
+
+	if decoder.Remaining() < fixedHeaderSizeV1 {
+		return fmt.Errorf("v1 message: buffer too small: need at least %d bytes for the fixed header, have %d", fixedHeaderSizeV1, decoder.Remaining())
+	}
+	if mx.Header.NumRequiredSignatures, err = decoder.ReadUint8(); err != nil {
+		return fmt.Errorf("unable to decode mx.Header.NumRequiredSignatures: %w", err)
+	}
+	if mx.Header.NumReadonlySignedAccounts, err = decoder.ReadUint8(); err != nil {
+		return fmt.Errorf("unable to decode mx.Header.NumReadonlySignedAccounts: %w", err)
+	}
+	if mx.Header.NumReadonlyUnsignedAccounts, err = decoder.ReadUint8(); err != nil {
+		return fmt.Errorf("unable to decode mx.Header.NumReadonlyUnsignedAccounts: %w", err)
+	}
+
+	rawMask, err := decoder.ReadUint32(bin.LE)
+	if err != nil {
+		return fmt.Errorf("unable to decode v1 config mask: %w", err)
+	}
+	mask := TransactionConfigMask(rawMask)
+	if mask.HasUnknownBits() || mask.HasInvalidPriorityFeeBits() {
+		return fmt.Errorf("invalid transaction config mask: 0x%08x", rawMask)
+	}
+
+	if _, err := decoder.Read(mx.RecentBlockhash[:]); err != nil {
+		return fmt.Errorf("unable to decode mx.RecentBlockhash: %w", err)
+	}
+	numInstructions, err := decoder.ReadUint8()
+	if err != nil {
+		return fmt.Errorf("unable to decode numInstructions: %w", err)
+	}
+	numAccountKeys, err := decoder.ReadUint8()
+	if err != nil {
+		return fmt.Errorf("unable to decode numAccountKeys: %w", err)
+	}
+
+	if int(numAccountKeys)*32 > decoder.Remaining() {
+		return fmt.Errorf("numAccountKeys %d is too large for remaining bytes %d", numAccountKeys, decoder.Remaining())
+	}
+	mx.AccountKeys = make(PublicKeySlice, numAccountKeys)
+	for i := range mx.AccountKeys {
+		if _, err := decoder.Read(mx.AccountKeys[i][:]); err != nil {
+			return fmt.Errorf("unable to decode mx.AccountKeys[%d]: %w", i, err)
+		}
+	}
+
+	if mask.SizeOfConfig() > decoder.Remaining() {
+		return fmt.Errorf("v1 message: buffer too small for config values: need %d bytes, have %d", mask.SizeOfConfig(), decoder.Remaining())
+	}
+	if mask.HasPriorityFee() {
+		v, err := decoder.ReadUint64(bin.LE)
+		if err != nil {
+			return fmt.Errorf("unable to decode priority fee: %w", err)
+		}
+		mx.TransactionConfig.PriorityFee = &v
+	}
+	if mask.HasComputeUnitLimit() {
+		v, err := decoder.ReadUint32(bin.LE)
+		if err != nil {
+			return fmt.Errorf("unable to decode compute unit limit: %w", err)
+		}
+		mx.TransactionConfig.ComputeUnitLimit = &v
+	}
+	if mask.HasLoadedAccountsDataSize() {
+		v, err := decoder.ReadUint32(bin.LE)
+		if err != nil {
+			return fmt.Errorf("unable to decode loaded accounts data size limit: %w", err)
+		}
+		mx.TransactionConfig.LoadedAccountsDataSizeLimit = &v
+	}
+	if mask.HasHeapSize() {
+		v, err := decoder.ReadUint32(bin.LE)
+		if err != nil {
+			return fmt.Errorf("unable to decode heap size: %w", err)
+		}
+		mx.TransactionConfig.HeapSize = &v
+	}
+
+	if int(numInstructions)*instructionHeaderSizeV1 > decoder.Remaining() {
+		return fmt.Errorf("numInstructions %d is too large for remaining bytes %d", numInstructions, decoder.Remaining())
+	}
+	mx.Instructions = make([]CompiledInstruction, numInstructions)
+	numAccounts := make([]uint8, numInstructions)
+	dataLens := make([]uint16, numInstructions)
+	for i := range mx.Instructions {
+		programIDIndex, err := decoder.ReadUint8()
+		if err != nil {
+			return fmt.Errorf("unable to decode ix[%d].ProgramIDIndex: %w", i, err)
+		}
+		mx.Instructions[i].ProgramIDIndex = uint16(programIDIndex)
+		if numAccounts[i], err = decoder.ReadUint8(); err != nil {
+			return fmt.Errorf("unable to decode numAccounts for ix[%d]: %w", i, err)
+		}
+		if dataLens[i], err = decoder.ReadUint16(bin.LE); err != nil {
+			return fmt.Errorf("unable to decode dataLen for ix[%d]: %w", i, err)
+		}
+	}
+
+	for i := range mx.Instructions {
+		needed := int(numAccounts[i]) + int(dataLens[i])
+		if needed > decoder.Remaining() {
+			return fmt.Errorf("ix[%d]: payload of %d bytes is greater than remaining bytes %d", i, needed, decoder.Remaining())
+		}
+		ix := &mx.Instructions[i]
+		ix.Accounts = make([]uint16, numAccounts[i])
+		for j := range ix.Accounts {
+			idx, err := decoder.ReadUint8()
+			if err != nil {
+				return fmt.Errorf("unable to decode accountIndex for ix[%d].Accounts[%d]: %w", i, j, err)
+			}
+			ix.Accounts[j] = uint16(idx)
+		}
+		data, err := decoder.ReadBytes(int(dataLens[i]))
+		if err != nil {
+			return fmt.Errorf("unable to decode dataBytes for ix[%d]: %w", i, err)
+		}
+		ix.Data = Base58(data)
+	}
+	return nil
+}

--- a/message_v1_test.go
+++ b/message_v1_test.go
@@ -1,0 +1,973 @@
+package solana
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"math/rand"
+	"testing"
+
+	bin "github.com/gagliardetto/binary"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Ported from solana-sdk message/src/versions/v1/{config,message}.rs and versions/mod.rs.
+
+// v1MessageBuilder mirrors the upstream test-only `v1::MessageBuilder`.
+type v1MessageBuilder struct {
+	msg Message
+}
+
+func newV1MessageBuilder() *v1MessageBuilder {
+	b := &v1MessageBuilder{}
+	b.msg.version = MessageVersionV1
+	return b
+}
+
+func (b *v1MessageBuilder) requiredSignatures(n uint8) *v1MessageBuilder {
+	b.msg.Header.NumRequiredSignatures = n
+	return b
+}
+
+func (b *v1MessageBuilder) readonlySignedAccounts(n uint8) *v1MessageBuilder {
+	b.msg.Header.NumReadonlySignedAccounts = n
+	return b
+}
+
+func (b *v1MessageBuilder) readonlyUnsignedAccounts(n uint8) *v1MessageBuilder {
+	b.msg.Header.NumReadonlyUnsignedAccounts = n
+	return b
+}
+
+func (b *v1MessageBuilder) lifetimeSpecifier(h Hash) *v1MessageBuilder {
+	b.msg.RecentBlockhash = h
+	return b
+}
+
+func (b *v1MessageBuilder) priorityFee(v uint64) *v1MessageBuilder {
+	b.msg.TransactionConfig = b.msg.TransactionConfig.WithPriorityFee(v)
+	return b
+}
+
+func (b *v1MessageBuilder) computeUnitLimit(v uint32) *v1MessageBuilder {
+	b.msg.TransactionConfig = b.msg.TransactionConfig.WithComputeUnitLimit(v)
+	return b
+}
+
+func (b *v1MessageBuilder) loadedAccountsDataSizeLimit(v uint32) *v1MessageBuilder {
+	b.msg.TransactionConfig = b.msg.TransactionConfig.WithLoadedAccountsDataSizeLimit(v)
+	return b
+}
+
+func (b *v1MessageBuilder) heapSize(v uint32) *v1MessageBuilder {
+	b.msg.TransactionConfig = b.msg.TransactionConfig.WithHeapSize(v)
+	return b
+}
+
+func (b *v1MessageBuilder) accounts(keys ...PublicKey) *v1MessageBuilder {
+	b.msg.AccountKeys = PublicKeySlice(keys)
+	return b
+}
+
+func (b *v1MessageBuilder) instruction(ix CompiledInstruction) *v1MessageBuilder {
+	b.msg.Instructions = append(b.msg.Instructions, ix)
+	return b
+}
+
+func (b *v1MessageBuilder) instructions(ixs ...CompiledInstruction) *v1MessageBuilder {
+	b.msg.Instructions = ixs
+	return b
+}
+
+// build validates the message (like upstream `MessageBuilder::build`) and returns it.
+func (b *v1MessageBuilder) build(t *testing.T) Message {
+	t.Helper()
+	require.NoError(t, b.msg.Sanitize())
+	return b.msg
+}
+
+func uniqueHash() Hash {
+	var h Hash
+	copy(h[:], newUniqueKey().Bytes())
+	return h
+}
+
+func uniqueKeys(n int) []PublicKey {
+	out := make([]PublicKey, n)
+	for i := range out {
+		out[i] = newUniqueKey()
+	}
+	return out
+}
+
+// createTestV1Message mirrors upstream `create_test_message`.
+func createTestV1Message(t *testing.T) Message {
+	t.Helper()
+	return newV1MessageBuilder().
+		requiredSignatures(1).
+		readonlyUnsignedAccounts(1).
+		lifetimeSpecifier(uniqueHash()).
+		accounts(
+			newUniqueKey(), // fee payer
+			newUniqueKey(), // program
+			newUniqueKey(), // readonly account
+		).
+		computeUnitLimit(200_000).
+		instruction(CompiledInstruction{
+			ProgramIDIndex: 1,
+			Accounts:       []uint16{0, 2},
+			Data:           []byte{1, 2, 3, 4},
+		}).
+		build(t)
+}
+
+func mustMarshalV1(t *testing.T, msg *Message) []byte {
+	t.Helper()
+	out, err := msg.MarshalV1()
+	require.NoError(t, err)
+	return out
+}
+
+func mustUnmarshalV1(t *testing.T, data []byte) Message {
+	t.Helper()
+	var msg Message
+	require.NoError(t, msg.UnmarshalWithDecoder(bin.NewBinDecoder(data)))
+	return msg
+}
+
+// ---------------------------------------------------------------------------
+// config.rs
+// ---------------------------------------------------------------------------
+
+func TestV1ConfigMask_HasUnknownBits(t *testing.T) {
+	assert.False(t, TransactionConfigMask(0).HasUnknownBits())
+	assert.False(t, TransactionConfigMask(0b11111).HasUnknownBits())
+	assert.True(t, TransactionConfigMask(0b100000).HasUnknownBits())
+	assert.True(t, TransactionConfigMask(0x80000000).HasUnknownBits())
+	assert.True(t, TransactionConfigMask(0b111111).HasUnknownBits())
+}
+
+func TestV1ConfigMask_HasPriorityFeeRequiresBothBits(t *testing.T) {
+	assert.False(t, TransactionConfigMask(0).HasPriorityFee())
+	assert.False(t, TransactionConfigMask(0b01).HasPriorityFee())
+	assert.False(t, TransactionConfigMask(0b10).HasPriorityFee())
+	assert.True(t, TransactionConfigMask(0b11).HasPriorityFee())
+}
+
+func TestV1ConfigMask_HasInvalidPriorityFeeBits(t *testing.T) {
+	assert.False(t, TransactionConfigMask(0).HasInvalidPriorityFeeBits())
+	assert.True(t, TransactionConfigMask(0b01).HasInvalidPriorityFeeBits())
+	assert.True(t, TransactionConfigMask(0b10).HasInvalidPriorityFeeBits())
+	assert.False(t, TransactionConfigMask(0b11).HasInvalidPriorityFeeBits())
+}
+
+func TestV1ConfigMask_FieldMethods(t *testing.T) {
+	mask := TransactionConfigMask(0b11100)
+	assert.True(t, mask.HasComputeUnitLimit())
+	assert.True(t, mask.HasLoadedAccountsDataSize())
+	assert.True(t, mask.HasHeapSize())
+
+	mask = TransactionConfigMask(0)
+	assert.False(t, mask.HasComputeUnitLimit())
+	assert.False(t, mask.HasLoadedAccountsDataSize())
+	assert.False(t, mask.HasHeapSize())
+}
+
+func TestV1ConfigMask_SizeOfConfig(t *testing.T) {
+	assert.Equal(t, 0, TransactionConfigMask(0).SizeOfConfig())
+	assert.Equal(t, 8, TransactionConfigMask(0b11).SizeOfConfig())
+	assert.Equal(t, 4, TransactionConfigMask(0b100).SizeOfConfig())
+	assert.Equal(t, 20, TransactionConfigMask(0b11111).SizeOfConfig())
+}
+
+func TestV1ConfigMask_FromConfig(t *testing.T) {
+	cfg := TransactionConfig{}.WithPriorityFee(1000).WithComputeUnitLimit(200_000)
+	mask := cfg.Mask()
+	assert.True(t, mask.HasPriorityFee())
+	assert.True(t, mask.HasComputeUnitLimit())
+	assert.False(t, mask.HasLoadedAccountsDataSize())
+	assert.False(t, mask.HasHeapSize())
+	assert.Equal(t, TransactionConfigMask(0b111), mask)
+	assert.Equal(t, 12, cfg.Size())
+	assert.Equal(t, mask.SizeOfConfig(), cfg.Size())
+}
+
+func TestV1ConfigMask_InvariantsForAllKnownBitPatterns(t *testing.T) {
+	for raw := uint32(0); raw < 1<<5; raw++ {
+		mask := TransactionConfigMask(raw)
+		assert.False(t, mask.HasUnknownBits(), "raw=%b", raw)
+		if mask.HasPriorityFee() {
+			assert.False(t, mask.HasInvalidPriorityFeeBits())
+		}
+		expected := 0
+		if mask.HasPriorityFee() {
+			expected += 8
+		}
+		if mask.HasComputeUnitLimit() {
+			expected += 4
+		}
+		if mask.HasLoadedAccountsDataSize() {
+			expected += 4
+		}
+		if mask.HasHeapSize() {
+			expected += 4
+		}
+		assert.Equal(t, expected, mask.SizeOfConfig(), "raw=%b", raw)
+	}
+}
+
+func TestV1Config_BuilderSetsAllFields(t *testing.T) {
+	cfg := TransactionConfig{}.
+		WithPriorityFee(1000).
+		WithComputeUnitLimit(200_000).
+		WithLoadedAccountsDataSizeLimit(64 * 1024).
+		WithHeapSize(64 * 1024)
+
+	require.NotNil(t, cfg.PriorityFee)
+	require.NotNil(t, cfg.ComputeUnitLimit)
+	require.NotNil(t, cfg.LoadedAccountsDataSizeLimit)
+	require.NotNil(t, cfg.HeapSize)
+	assert.Equal(t, uint64(1000), *cfg.PriorityFee)
+	assert.Equal(t, uint32(200_000), *cfg.ComputeUnitLimit)
+	assert.Equal(t, uint32(64*1024), *cfg.LoadedAccountsDataSizeLimit)
+	assert.Equal(t, uint32(64*1024), *cfg.HeapSize)
+	assert.False(t, cfg.IsEmpty())
+	assert.True(t, TransactionConfig{}.IsEmpty())
+	assert.Equal(t, TransactionConfigMaskKnownBits, cfg.Mask())
+}
+
+func TestV1Config_WithDoesNotAlias(t *testing.T) {
+	base := TransactionConfig{}.WithComputeUnitLimit(1)
+	a := base.WithComputeUnitLimit(2)
+	b := base.WithPriorityFee(3)
+	assert.Equal(t, uint32(1), *base.ComputeUnitLimit)
+	assert.Equal(t, uint32(2), *a.ComputeUnitLimit)
+	assert.Nil(t, base.PriorityFee)
+	assert.Equal(t, uint32(1), *b.ComputeUnitLimit)
+	assert.Equal(t, uint64(3), *b.PriorityFee)
+}
+
+// ---------------------------------------------------------------------------
+// message.rs
+// ---------------------------------------------------------------------------
+
+func TestV1_FeePayerReturnsFirstAccount(t *testing.T) {
+	feePayer := newUniqueKey()
+	msg := newV1MessageBuilder().
+		requiredSignatures(1).
+		lifetimeSpecifier(uniqueHash()).
+		accounts(feePayer, newUniqueKey()).
+		build(t)
+	assert.Equal(t, feePayer, msg.AccountKeys[0])
+	assert.Equal(t, PublicKeySlice{feePayer}, msg.Signers())
+}
+
+func TestV1_IsSignerChecksSignatureRequirement(t *testing.T) {
+	msg := createTestV1Message(t)
+	assert.True(t, msg.IsSigner(msg.AccountKeys[0]))  // fee payer is signer
+	assert.False(t, msg.IsSigner(msg.AccountKeys[1])) // program is not signer
+	assert.False(t, msg.IsSigner(msg.AccountKeys[2])) // readonly account is not signer
+}
+
+func TestV1_IsSignerWritableIdentifiesWritableSigners(t *testing.T) {
+	msg := newV1MessageBuilder().
+		requiredSignatures(3).
+		readonlySignedAccounts(1). // last signer is readonly
+		lifetimeSpecifier(uniqueHash()).
+		accounts(
+			newUniqueKey(), // 0: writable signer
+			newUniqueKey(), // 1: writable signer
+			newUniqueKey(), // 2: readonly signer
+			newUniqueKey(), // 3: non-signer
+		).
+		build(t)
+
+	isSignerWritable := func(i int) bool {
+		key := msg.AccountKeys[i]
+		w, err := msg.IsWritable(key)
+		require.NoError(t, err)
+		return msg.IsSigner(key) && w
+	}
+	assert.True(t, isSignerWritable(0))
+	assert.True(t, isSignerWritable(1))
+	assert.False(t, isSignerWritable(2))
+	assert.False(t, isSignerWritable(3))
+}
+
+func TestV1_IsSignerWritableAllWritableWhenNoReadonly(t *testing.T) {
+	msg := newV1MessageBuilder().
+		requiredSignatures(2).
+		readonlySignedAccounts(0).
+		lifetimeSpecifier(uniqueHash()).
+		accounts(newUniqueKey(), newUniqueKey(), newUniqueKey()).
+		build(t)
+
+	metas, err := msg.AccountMetaList()
+	require.NoError(t, err)
+	assert.True(t, metas[0].IsSigner && metas[0].IsWritable)
+	assert.True(t, metas[1].IsSigner && metas[1].IsWritable)
+	assert.False(t, metas[2].IsSigner)
+	assert.True(t, metas[2].IsWritable) // writable unsigned (no readonly unsigned)
+}
+
+func TestV1_IsWritableIndexRespectsHeaderLayout(t *testing.T) {
+	msg := createTestV1Message(t)
+	// Account layout: [writable signer (fee payer), writable unsigned (program), readonly unsigned]
+	metas, err := msg.AccountMetaList()
+	require.NoError(t, err)
+	assert.True(t, metas[0].IsWritable)  // fee payer is writable
+	assert.True(t, metas[1].IsWritable)  // program position is writable unsigned
+	assert.False(t, metas[2].IsWritable) // last account is readonly
+
+	assert.True(t, msg.IsWritableStatic(msg.AccountKeys[0]))
+	assert.True(t, msg.IsWritableStatic(msg.AccountKeys[1]))
+	assert.False(t, msg.IsWritableStatic(msg.AccountKeys[2]))
+}
+
+func TestV1_IsWritableIndexHandlesMixedSignerPermissions(t *testing.T) {
+	msg := createTestV1Message(t)
+	// 2 signers: first writable, second readonly
+	msg.Header.NumRequiredSignatures = 2
+	msg.Header.NumReadonlySignedAccounts = 1
+	msg.Header.NumReadonlyUnsignedAccounts = 1
+	msg.AccountKeys = PublicKeySlice{
+		newUniqueKey(), // writable signer
+		newUniqueKey(), // readonly signer
+		newUniqueKey(), // readonly unsigned
+	}
+	msg.Instructions[0].ProgramIDIndex = 2
+	msg.Instructions[0].Accounts = []uint16{0, 1}
+
+	require.NoError(t, msg.Sanitize())
+	metas, err := msg.AccountMetaList()
+	require.NoError(t, err)
+	assert.True(t, metas[0].IsWritable)  // writable signer
+	assert.False(t, metas[1].IsWritable) // readonly signer
+	assert.False(t, metas[2].IsWritable) // readonly unsigned
+	w, err := msg.IsWritable(newUniqueKey())
+	require.NoError(t, err)
+	assert.False(t, w) // unknown key
+}
+
+// -- sanitize --
+
+func TestV1Sanitize_AcceptsValidMessage(t *testing.T) {
+	msg := createTestV1Message(t)
+	require.NoError(t, msg.Sanitize())
+}
+
+func TestV1Sanitize_RejectsZeroSigners(t *testing.T) {
+	msg := createTestV1Message(t)
+	msg.Header.NumRequiredSignatures = 0
+	err := msg.Sanitize()
+	require.Error(t, err)
+	assert.True(t, IsSanitizeError(err))
+	assert.Contains(t, err.Error(), "no writable signer")
+}
+
+func TestV1Sanitize_RejectsOver12Signatures(t *testing.T) {
+	msg := createTestV1Message(t)
+	msg.Header.NumRequiredSignatures = MaxSignaturesV1 + 1
+	msg.AccountKeys = uniqueKeys(MaxSignaturesV1 + 1)
+	err := msg.Sanitize()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too many signatures")
+}
+
+func TestV1Sanitize_RejectsOver64Addresses(t *testing.T) {
+	msg := createTestV1Message(t)
+	msg.AccountKeys = uniqueKeys(65)
+	err := msg.Sanitize()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too many addresses")
+}
+
+func TestV1Sanitize_RejectsOver64Instructions(t *testing.T) {
+	msg := createTestV1Message(t)
+	msg.Instructions = make([]CompiledInstruction, 65)
+	for i := range msg.Instructions {
+		msg.Instructions[i] = CompiledInstruction{ProgramIDIndex: 1, Accounts: []uint16{0}}
+	}
+	err := msg.Sanitize()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too many instructions")
+}
+
+func TestV1Sanitize_RejectsInsufficientAccountsForHeader(t *testing.T) {
+	msg := createTestV1Message(t)
+	msg.Header.NumReadonlyUnsignedAccounts = 10
+	err := msg.Sanitize()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "more accounts than available")
+}
+
+func TestV1Sanitize_RejectsAllSignersReadonly(t *testing.T) {
+	msg := createTestV1Message(t)
+	msg.Header.NumReadonlySignedAccounts = 1
+	err := msg.Sanitize()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no writable signer")
+}
+
+func TestV1Sanitize_RejectsDuplicateAddresses(t *testing.T) {
+	msg := createTestV1Message(t)
+	msg.AccountKeys[1] = msg.AccountKeys[0]
+	err := msg.Sanitize()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate")
+}
+
+func TestV1Sanitize_RejectsUnalignedHeapSize(t *testing.T) {
+	msg := createTestV1Message(t)
+	msg.TransactionConfig = msg.TransactionConfig.WithHeapSize(MinHeapSizeV1 + 1)
+	err := msg.Sanitize()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "multiple of 1024")
+}
+
+func TestV1Sanitize_AcceptsAlignedHeapSize(t *testing.T) {
+	msg := createTestV1Message(t)
+	msg.TransactionConfig = msg.TransactionConfig.WithHeapSize(65536)
+	require.NoError(t, msg.Sanitize())
+}
+
+// Upstream #699: heap size bounds.
+func TestV1Sanitize_HeapSizeBounds(t *testing.T) {
+	msg := createTestV1Message(t)
+
+	msg.TransactionConfig = msg.TransactionConfig.WithHeapSize(MinHeapSizeV1 - 1024)
+	require.Error(t, msg.Sanitize(), "below min")
+
+	msg.TransactionConfig = msg.TransactionConfig.WithHeapSize(MaxHeapSizeV1 + 1024)
+	require.Error(t, msg.Sanitize(), "above max")
+
+	msg.TransactionConfig = msg.TransactionConfig.WithHeapSize(MinHeapSizeV1)
+	require.NoError(t, msg.Sanitize(), "at min")
+
+	msg.TransactionConfig = msg.TransactionConfig.WithHeapSize(MaxHeapSizeV1)
+	require.NoError(t, msg.Sanitize(), "at max")
+
+	msg.TransactionConfig = msg.TransactionConfig.WithHeapSize(0)
+	require.Error(t, msg.Sanitize(), "zero (multiple of 1024 but below min)")
+}
+
+func TestV1Sanitize_RejectsInvalidProgramIDIndex(t *testing.T) {
+	msg := createTestV1Message(t)
+	msg.Instructions[0].ProgramIDIndex = 99
+	err := msg.Sanitize()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "program_id_index 99 out of bounds")
+}
+
+func TestV1Sanitize_RejectsFeePayerAsProgram(t *testing.T) {
+	msg := createTestV1Message(t)
+	msg.Instructions[0].ProgramIDIndex = 0
+	err := msg.Sanitize()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot be 0")
+}
+
+func TestV1Sanitize_RejectsInstructionWithTooManyAccounts(t *testing.T) {
+	msg := createTestV1Message(t)
+	msg.Instructions[0].Accounts = make([]uint16, 256)
+	err := msg.Sanitize()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too many accounts")
+}
+
+func TestV1Sanitize_RejectsInvalidInstructionAccountIndex(t *testing.T) {
+	msg := createTestV1Message(t)
+	msg.Instructions[0].Accounts = []uint16{0, 99}
+	err := msg.Sanitize()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "account index 99 out of bounds")
+}
+
+func TestV1Sanitize_Accepts64Addresses(t *testing.T) {
+	msg := createTestV1Message(t)
+	msg.AccountKeys = uniqueKeys(MaxAddressesV1)
+	msg.Header.NumRequiredSignatures = 1
+	msg.Header.NumReadonlySignedAccounts = 0
+	msg.Header.NumReadonlyUnsignedAccounts = 1
+	msg.Instructions[0].ProgramIDIndex = 1
+	msg.Instructions[0].Accounts = []uint16{0, 2}
+	require.NoError(t, msg.Sanitize())
+}
+
+func TestV1Sanitize_Accepts64Instructions(t *testing.T) {
+	msg := createTestV1Message(t)
+	msg.Instructions = make([]CompiledInstruction, MaxInstructionsV1)
+	for i := range msg.Instructions {
+		msg.Instructions[i] = CompiledInstruction{ProgramIDIndex: 1, Accounts: []uint16{0, 2}, Data: []byte{1, 2, 3}}
+	}
+	require.NoError(t, msg.Sanitize())
+}
+
+// V1 messages are never silently demoted to v0/legacy.
+func TestV1_NoSilentDemotion(t *testing.T) {
+	msg := createTestV1Message(t)
+
+	msg.SetAddressTableLookups(nil)
+	assert.Equal(t, MessageVersionV1, msg.GetVersion())
+	msg.AddAddressTableLookup(MessageAddressTableLookup{AccountKey: newUniqueKey(), WritableIndexes: []uint8{0}})
+	assert.Equal(t, MessageVersionV1, msg.GetVersion())
+	_, err := msg.MarshalBinary()
+	require.Error(t, err)
+	msg.SetAddressTableLookups(nil)
+
+	// Leaving V1 with a non-empty config is an error; clearing it first works.
+	_, err = msg.SetVersion(MessageVersionLegacy)
+	require.Error(t, err)
+	_, err = msg.SetVersion(MessageVersionV0)
+	require.Error(t, err)
+	assert.Equal(t, MessageVersionV1, msg.GetVersion())
+	msg.TransactionConfig = TransactionConfig{}
+	_, err = msg.SetVersion(MessageVersionLegacy)
+	require.NoError(t, err)
+	assert.Equal(t, MessageVersionLegacy, msg.GetVersion())
+}
+
+// Reusing a Message across decodes must not leak a v1 config into legacy/v0.
+func TestV1_DecodeResetsConfigOnReuse(t *testing.T) {
+	v1 := createTestV1Message(t)
+	var m Message
+	require.NoError(t, m.UnmarshalWithDecoder(bin.NewBinDecoder(mustMarshalV1(t, &v1))))
+	require.False(t, m.TransactionConfig.IsEmpty())
+
+	legacy := Message{Header: MessageHeader{NumRequiredSignatures: 1}, AccountKeys: PublicKeySlice{newUniqueKey()}}
+	raw, err := legacy.MarshalLegacy()
+	require.NoError(t, err)
+	require.NoError(t, m.UnmarshalWithDecoder(bin.NewBinDecoder(raw)))
+	assert.Equal(t, MessageVersionLegacy, m.GetVersion())
+	assert.True(t, m.TransactionConfig.IsEmpty())
+	assert.Nil(t, m.AddressTableLookups)
+}
+
+func TestV1Sanitize_RejectsAddressTableLookups(t *testing.T) {
+	msg := createTestV1Message(t)
+	msg.AddressTableLookups = MessageAddressTableLookupSlice{{AccountKey: newUniqueKey(), WritableIndexes: []uint8{0}}}
+	err := msg.Sanitize()
+	require.Error(t, err)
+	assert.True(t, IsSanitizeError(err))
+	_, err = msg.MarshalBinary()
+	require.Error(t, err)
+}
+
+// -- serialization --
+
+func TestV1_SizeMatchesSerializedLength(t *testing.T) {
+	cases := []Message{
+		// Minimal message
+		newV1MessageBuilder().
+			requiredSignatures(1).
+			lifetimeSpecifier(uniqueHash()).
+			accounts(newUniqueKey()).
+			build(t),
+		// With config
+		newV1MessageBuilder().
+			requiredSignatures(1).
+			lifetimeSpecifier(uniqueHash()).
+			accounts(newUniqueKey(), newUniqueKey()).
+			priorityFee(1000).
+			computeUnitLimit(200_000).
+			instruction(CompiledInstruction{ProgramIDIndex: 1, Accounts: []uint16{0}, Data: []byte{1, 2, 3, 4}}).
+			build(t),
+		// Multiple instructions with varying data
+		newV1MessageBuilder().
+			requiredSignatures(2).
+			readonlySignedAccounts(1).
+			readonlyUnsignedAccounts(1).
+			lifetimeSpecifier(uniqueHash()).
+			accounts(newUniqueKey(), newUniqueKey(), newUniqueKey(), newUniqueKey()).
+			heapSize(65536).
+			instructions(
+				CompiledInstruction{ProgramIDIndex: 2, Accounts: []uint16{0, 1}, Data: []byte{}},
+				CompiledInstruction{ProgramIDIndex: 3, Accounts: []uint16{0, 1, 2}, Data: make([]byte, 100)},
+			).
+			build(t),
+	}
+	for i := range cases {
+		out := mustMarshalV1(t, &cases[i])
+		assert.Equal(t, cases[i].sizeV1(), len(out), "case %d", i)
+	}
+}
+
+func TestV1_ByteLayoutWithoutConfig(t *testing.T) {
+	feePayer := PublicKey{}
+	program := PublicKey{}
+	var blockhash Hash
+	for i := range 32 {
+		feePayer[i] = 1
+		program[i] = 2
+		blockhash[i] = 0xAB
+	}
+
+	msg := newV1MessageBuilder().
+		requiredSignatures(1).
+		lifetimeSpecifier(blockhash).
+		accounts(feePayer, program).
+		instruction(CompiledInstruction{ProgramIDIndex: 1, Accounts: []uint16{0}, Data: []byte{0xDE, 0xAD}}).
+		build(t)
+
+	got := mustMarshalV1(t, &msg)
+
+	// Build expected bytes manually per SIMD-0385.
+	expected := []byte{0x81}                // version byte
+	expected = append(expected, 1, 0, 0)    // header
+	expected = append(expected, 0, 0, 0, 0) // ConfigMask = 0
+	expected = append(expected, blockhash[:]...)
+	expected = append(expected, 1) // NumInstructions
+	expected = append(expected, 2) // NumAddresses
+	expected = append(expected, feePayer[:]...)
+	expected = append(expected, program[:]...)
+	// ConfigValues: none
+	expected = append(expected, 1)    // program_id_index
+	expected = append(expected, 1)    // num_accounts
+	expected = append(expected, 2, 0) // data_len u16 LE
+	expected = append(expected, 0)    // account index 0
+	expected = append(expected, 0xDE, 0xAD)
+	assert.Equal(t, expected, got)
+
+	// And it round-trips.
+	back := mustUnmarshalV1(t, got)
+	assert.Equal(t, MessageVersionV1, back.GetVersion())
+	assert.Equal(t, msg.Header, back.Header)
+	assert.Equal(t, msg.AccountKeys, back.AccountKeys)
+	assert.Equal(t, msg.RecentBlockhash, back.RecentBlockhash)
+	assert.Equal(t, msg.Instructions, back.Instructions)
+	assert.True(t, back.TransactionConfig.IsEmpty())
+}
+
+func TestV1_ByteLayoutWithConfig(t *testing.T) {
+	feePayer := PublicKey{}
+	program := PublicKey{}
+	var blockhash Hash
+	for i := range 32 {
+		feePayer[i] = 1
+		program[i] = 2
+		blockhash[i] = 0xBB
+	}
+
+	msg := newV1MessageBuilder().
+		requiredSignatures(1).
+		lifetimeSpecifier(blockhash).
+		accounts(feePayer, program).
+		priorityFee(0x0102030405060708).
+		computeUnitLimit(0x11223344).
+		instruction(CompiledInstruction{ProgramIDIndex: 1, Accounts: []uint16{}, Data: []byte{}}).
+		build(t)
+
+	got := mustMarshalV1(t, &msg)
+
+	expected := []byte{0x81, 1, 0, 0}
+	// ConfigMask: priority fee (bits 0,1) + CU limit (bit 2) = 0b111 = 7
+	expected = append(expected, 7, 0, 0, 0)
+	expected = append(expected, blockhash[:]...)
+	expected = append(expected, 1, 2)
+	expected = append(expected, feePayer[:]...)
+	expected = append(expected, program[:]...)
+	expected = binary.LittleEndian.AppendUint64(expected, 0x0102030405060708)
+	expected = binary.LittleEndian.AppendUint32(expected, 0x11223344)
+	expected = append(expected, 1)    // program_id_index
+	expected = append(expected, 0)    // num_accounts
+	expected = append(expected, 0, 0) // data_len
+	assert.Equal(t, expected, got)
+}
+
+func TestV1_RoundtripPreservesAllConfigFields(t *testing.T) {
+	msg := newV1MessageBuilder().
+		requiredSignatures(1).
+		lifetimeSpecifier(uniqueHash()).
+		accounts(newUniqueKey(), newUniqueKey()).
+		priorityFee(1000).
+		computeUnitLimit(200_000).
+		loadedAccountsDataSizeLimit(1_000_000).
+		heapSize(65536).
+		instruction(CompiledInstruction{ProgramIDIndex: 1, Accounts: []uint16{0}, Data: []byte{}}).
+		build(t)
+
+	back := mustUnmarshalV1(t, mustMarshalV1(t, &msg))
+	assert.Equal(t, msg.TransactionConfig, back.TransactionConfig)
+	assert.Equal(t, uint64(1000), *back.TransactionConfig.PriorityFee)
+	assert.Equal(t, uint32(200_000), *back.TransactionConfig.ComputeUnitLimit)
+	assert.Equal(t, uint32(1_000_000), *back.TransactionConfig.LoadedAccountsDataSizeLimit)
+	assert.Equal(t, uint32(65536), *back.TransactionConfig.HeapSize)
+}
+
+// Upstream #621/#622: config mask validation during deserialization.
+func TestV1_DeserializeRejectsUnknownConfigMaskBits(t *testing.T) {
+	msg := createTestV1Message(t)
+	data := mustMarshalV1(t, &msg)
+	// mask is at offset 4..8 (after version byte + 3-byte header)
+	binary.LittleEndian.PutUint32(data[4:8], uint32(TransactionConfigMaskKnownBits)|(1<<5))
+	var back Message
+	err := back.UnmarshalWithDecoder(bin.NewBinDecoder(data))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid transaction config mask")
+}
+
+func TestV1_DeserializeRejectsPartialPriorityFeeBits(t *testing.T) {
+	msg := createTestV1Message(t)
+	data := mustMarshalV1(t, &msg)
+	for _, bad := range []uint32{0b01, 0b10} {
+		binary.LittleEndian.PutUint32(data[4:8], bad)
+		var back Message
+		err := back.UnmarshalWithDecoder(bin.NewBinDecoder(data))
+		require.Error(t, err, "mask %b", bad)
+		assert.Contains(t, err.Error(), "invalid transaction config mask")
+	}
+}
+
+func TestV1_DeserializeRejectsWrongPrefix(t *testing.T) {
+	msg := createTestV1Message(t)
+	data := mustMarshalV1(t, &msg)
+	data[0] = 0x80
+	var back Message
+	err := back.UnmarshalV1(bin.NewBinDecoder(data))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid v1 message version prefix")
+}
+
+// Every strict prefix of a valid encoding must fail to decode (and never panic).
+func TestV1_DeserializeBufferTooSmall(t *testing.T) {
+	msg := newV1MessageBuilder().
+		requiredSignatures(2).
+		readonlySignedAccounts(1).
+		readonlyUnsignedAccounts(1).
+		lifetimeSpecifier(uniqueHash()).
+		accounts(newUniqueKey(), newUniqueKey(), newUniqueKey(), newUniqueKey()).
+		priorityFee(1).
+		computeUnitLimit(2).
+		loadedAccountsDataSizeLimit(3).
+		heapSize(MinHeapSizeV1).
+		instructions(
+			CompiledInstruction{ProgramIDIndex: 2, Accounts: []uint16{0, 1}, Data: []byte{9, 9, 9}},
+			CompiledInstruction{ProgramIDIndex: 3, Accounts: []uint16{}, Data: []byte{}},
+			CompiledInstruction{ProgramIDIndex: 3, Accounts: []uint16{1}, Data: []byte{7}},
+		).
+		build(t)
+	data := mustMarshalV1(t, &msg)
+	for n := 0; n < len(data); n++ {
+		var back Message
+		err := back.UnmarshalWithDecoder(bin.NewBinDecoder(data[:n]))
+		require.Error(t, err, "prefix of %d/%d bytes must fail", n, len(data))
+	}
+	// The full buffer decodes fine and matches.
+	back := mustUnmarshalV1(t, data)
+	assert.Equal(t, msg.Instructions, back.Instructions)
+	assert.Equal(t, msg.TransactionConfig, back.TransactionConfig)
+}
+
+// ---------------------------------------------------------------------------
+// versions/mod.rs
+// ---------------------------------------------------------------------------
+
+// Port of the proptest `test_v1_message_raw_bytes_roundtrip` using a seeded PRNG.
+func TestV1_MessageRawBytesRoundtrip(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x5385))
+	optU64 := func() *uint64 {
+		if rng.Intn(2) == 0 {
+			return nil
+		}
+		v := rng.Uint64()
+		return &v
+	}
+	optU32 := func(max int) *uint32 {
+		if rng.Intn(2) == 0 {
+			return nil
+		}
+		v := uint32(rng.Intn(max + 1))
+		return &v
+	}
+
+	for iter := 0; iter < 200; iter++ {
+		numAccounts := 12 + rng.Intn(64-12+1)
+		requiredSignatures := 1 + rng.Intn(12)
+		keys := make(PublicKeySlice, numAccounts)
+		for i := range keys {
+			rng.Read(keys[i][:])
+		}
+		var lifetime Hash
+		rng.Read(lifetime[:])
+
+		cfg := TransactionConfig{
+			PriorityFee:                 optU64(),
+			ComputeUnitLimit:            optU32(1_400_000),
+			LoadedAccountsDataSizeLimit: optU32(20_480),
+		}
+		if rng.Intn(2) == 1 {
+			v := uint32(rng.Intn(33)) * 1024
+			cfg.HeapSize = &v
+		}
+
+		programIDIndex := uint16(1 + rng.Intn(numAccounts-1))
+		numIxAccounts := requiredSignatures + rng.Intn(numAccounts-requiredSignatures+1)
+		ixAccounts := make([]uint16, numIxAccounts)
+		for i := range ixAccounts {
+			ixAccounts[i] = uint16(rng.Intn(numAccounts))
+		}
+		data := make([]byte, rng.Intn(2049))
+		rng.Read(data)
+
+		original := Message{
+			version: MessageVersionV1,
+			Header: MessageHeader{
+				NumRequiredSignatures: uint8(requiredSignatures),
+			},
+			RecentBlockhash:   lifetime,
+			AccountKeys:       keys,
+			TransactionConfig: cfg,
+			Instructions: []CompiledInstruction{{
+				ProgramIDIndex: programIDIndex,
+				Accounts:       ixAccounts,
+				Data:           data,
+			}},
+		}
+
+		bytes := mustMarshalV1(t, &original)
+		require.Equal(t, byte(0x81), bytes[0])
+		require.Equal(t, original.sizeV1(), len(bytes))
+
+		parsed := mustUnmarshalV1(t, bytes)
+		assert.Equal(t, MessageVersionV1, parsed.GetVersion())
+		assert.Equal(t, original.Header, parsed.Header)
+		assert.Equal(t, original.RecentBlockhash, parsed.RecentBlockhash)
+		assert.Equal(t, original.AccountKeys, parsed.AccountKeys)
+		assert.Equal(t, original.TransactionConfig, parsed.TransactionConfig)
+		assert.Equal(t, original.Instructions, parsed.Instructions)
+
+		// MarshalBinary on the V1 message is the same as MarshalV1.
+		viaBinary, err := original.MarshalBinary()
+		require.NoError(t, err)
+		assert.Equal(t, bytes, viaBinary)
+
+		// Re-encoding the parsed message is byte-identical.
+		again, err := parsed.MarshalBinary()
+		require.NoError(t, err)
+		assert.Equal(t, bytes, again)
+	}
+}
+
+func TestV1_VersionedMessageJSONRoundtrip(t *testing.T) {
+	msg := newV1MessageBuilder().
+		requiredSignatures(1).
+		lifetimeSpecifier(uniqueHash()).
+		accounts(newUniqueKey(), newUniqueKey()).
+		priorityFee(1000).
+		computeUnitLimit(200_000).
+		instruction(CompiledInstruction{ProgramIDIndex: 1, Accounts: []uint16{0}, Data: []byte{1, 2, 3, 4}}).
+		build(t)
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"transactionConfig":{"priorityFee":1000,"computeUnitLimit":200000,"loadedAccountsDataSizeLimit":null,"heapSize":null}`)
+	assert.NotContains(t, string(data), "addressTableLookups")
+
+	var back Message
+	require.NoError(t, json.Unmarshal(data, &back))
+	assert.Equal(t, MessageVersionV1, back.GetVersion())
+	assert.Equal(t, msg.Header, back.Header)
+	assert.Equal(t, msg.AccountKeys, back.AccountKeys)
+	assert.Equal(t, msg.RecentBlockhash, back.RecentBlockhash)
+	assert.Equal(t, msg.Instructions, back.Instructions)
+	assert.Equal(t, msg.TransactionConfig, back.TransactionConfig)
+
+	// Both keys present with non-empty lookups: error (v0 and v1 are exclusive).
+	both := `{"accountKeys":[],"header":{"numRequiredSignatures":1,"numReadonlySignedAccounts":0,"numReadonlyUnsignedAccounts":0},"recentBlockhash":"11111111111111111111111111111111","instructions":[],"addressTableLookups":[{"accountKey":"11111111111111111111111111111111","writableIndexes":[0],"readonlyIndexes":[]}],"transactionConfig":{"priorityFee":null,"computeUnitLimit":5,"loadedAccountsDataSizeLimit":null,"heapSize":null}}`
+	var m2 Message
+	require.Error(t, json.Unmarshal([]byte(both), &m2))
+
+	// Empty lookups array alongside a config is tolerated: V1.
+	emptyLookups := `{"accountKeys":[],"header":{"numRequiredSignatures":1,"numReadonlySignedAccounts":0,"numReadonlyUnsignedAccounts":0},"recentBlockhash":"11111111111111111111111111111111","instructions":[],"addressTableLookups":[],"transactionConfig":{"priorityFee":null,"computeUnitLimit":5,"loadedAccountsDataSizeLimit":null,"heapSize":null}}`
+	require.NoError(t, json.Unmarshal([]byte(emptyLookups), &m2))
+	assert.Equal(t, MessageVersionV1, m2.GetVersion())
+	assert.Nil(t, m2.AddressTableLookups)
+	require.NotNil(t, m2.TransactionConfig.ComputeUnitLimit)
+	assert.Equal(t, uint32(5), *m2.TransactionConfig.ComputeUnitLimit)
+
+	// transactionConfig with all-null fields -> V1 with an empty config.
+	emptyCfg := `{"accountKeys":[],"header":{"numRequiredSignatures":1,"numReadonlySignedAccounts":0,"numReadonlyUnsignedAccounts":0},"recentBlockhash":"11111111111111111111111111111111","instructions":[],"transactionConfig":{"priorityFee":null,"computeUnitLimit":null,"loadedAccountsDataSizeLimit":null,"heapSize":null}}`
+	var m3 Message
+	require.NoError(t, json.Unmarshal([]byte(emptyCfg), &m3))
+	assert.Equal(t, MessageVersionV1, m3.GetVersion())
+	assert.True(t, m3.TransactionConfig.IsEmpty())
+
+	// A null transactionConfig reads as absent (the RPC omits it): legacy.
+	nullCfg := `{"accountKeys":[],"header":{"numRequiredSignatures":1,"numReadonlySignedAccounts":0,"numReadonlyUnsignedAccounts":0},"recentBlockhash":"11111111111111111111111111111111","instructions":[],"transactionConfig":null}`
+	var m4 Message
+	require.NoError(t, json.Unmarshal([]byte(nullCfg), &m4))
+	assert.Equal(t, MessageVersionLegacy, m4.GetVersion())
+}
+
+// Port of `test_v1_wincode_roundtrip`: fixed messages through the generic
+// MarshalBinary/UnmarshalWithDecoder path.
+func TestV1_WincodeRoundtrip(t *testing.T) {
+	msgs := []Message{
+		// Minimal message
+		newV1MessageBuilder().
+			requiredSignatures(1).
+			lifetimeSpecifier(uniqueHash()).
+			accounts(newUniqueKey(), newUniqueKey()).
+			instruction(CompiledInstruction{ProgramIDIndex: 1, Accounts: []uint16{0}, Data: []byte{}}).
+			build(t),
+		// With config
+		newV1MessageBuilder().
+			requiredSignatures(1).
+			lifetimeSpecifier(uniqueHash()).
+			accounts(newUniqueKey(), newUniqueKey()).
+			priorityFee(1000).
+			computeUnitLimit(200_000).
+			instruction(CompiledInstruction{ProgramIDIndex: 1, Accounts: []uint16{0}, Data: []byte{1, 2, 3, 4}}).
+			build(t),
+		// Multiple instructions
+		newV1MessageBuilder().
+			requiredSignatures(2).
+			lifetimeSpecifier(uniqueHash()).
+			accounts(newUniqueKey(), newUniqueKey(), newUniqueKey()).
+			heapSize(65536).
+			instructions(
+				CompiledInstruction{ProgramIDIndex: 2, Accounts: []uint16{0, 1}, Data: []byte{0xAA, 0xBB}},
+				CompiledInstruction{ProgramIDIndex: 2, Accounts: []uint16{1}, Data: []byte{0xCC}},
+			).
+			build(t),
+	}
+	for i := range msgs {
+		data, err := msgs[i].MarshalBinary()
+		require.NoError(t, err)
+		back := mustUnmarshalV1(t, data)
+		assert.Equal(t, MessageVersionV1, back.GetVersion())
+		assert.Equal(t, msgs[i].Header, back.Header)
+		assert.Equal(t, msgs[i].AccountKeys, back.AccountKeys)
+		assert.Equal(t, msgs[i].RecentBlockhash, back.RecentBlockhash)
+		assert.Equal(t, msgs[i].Instructions, back.Instructions)
+		assert.Equal(t, msgs[i].TransactionConfig, back.TransactionConfig)
+
+		// base64 helpers
+		var viaB64 Message
+		require.NoError(t, viaB64.UnmarshalBase64(msgs[i].ToBase64()))
+		assert.Equal(t, MessageVersionV1, viaB64.GetVersion())
+	}
+}
+
+// Golden vector from the Rust SDK (solana-message 4.4.0), case "a_empty_config".
+func TestV1_GoldenMessageBytesFromRustSDK(t *testing.T) {
+	const msgHex = "8101000200000000abababababababababababababababababababababababababababababababab01048a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c02020202020202020202020202020202020202020202020202020202020202020303030303030303030303030303030303030303030303030303030303030303101010101010101010101010101010101010101010101010101010101010101003030400000102deadbeef"
+	raw, err := hex.DecodeString(msgHex)
+	require.NoError(t, err)
+
+	msg := mustUnmarshalV1(t, raw)
+	assert.Equal(t, MessageVersionV1, msg.GetVersion())
+	assert.Equal(t, MessageHeader{NumRequiredSignatures: 1, NumReadonlySignedAccounts: 0, NumReadonlyUnsignedAccounts: 2}, msg.Header)
+	require.Len(t, msg.AccountKeys, 4)
+	assert.Equal(t, "AKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9", msg.AccountKeys[0].String())
+	assert.Equal(t, "8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR", msg.AccountKeys[1].String())
+	assert.Equal(t, "CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8", msg.AccountKeys[2].String())
+	assert.Equal(t, "25hjHpTATmkdET17ynDhf1MCuYNDn1z7wXfVw5iaxLAK", msg.AccountKeys[3].String())
+	assert.True(t, msg.TransactionConfig.IsEmpty())
+	require.Len(t, msg.Instructions, 1)
+	assert.Equal(t, CompiledInstruction{ProgramIDIndex: 3, Accounts: []uint16{0, 1, 2}, Data: []byte{0xDE, 0xAD, 0xBE, 0xEF}}, msg.Instructions[0])
+	require.NoError(t, msg.Sanitize())
+
+	again := mustMarshalV1(t, &msg)
+	assert.Equal(t, raw, again)
+}

--- a/programs/compute-budget/instruction.go
+++ b/programs/compute-budget/instruction.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package computebudget provides the ComputeBudget program instructions.
+// In v1 (SIMD-0385) transactions they are no-ops; use solana.TransactionConfig.
 package computebudget
 
 import (

--- a/rpc/examples/getBlock/getBlock.go
+++ b/rpc/examples/getBlock/getBlock.go
@@ -32,9 +32,10 @@ func main() {
 		panic(err)
 	}
 
-	// Mainnet blocks contain v0 (versioned) transactions; GetBlock
-	// requires MaxSupportedTransactionVersion or it errors out.
-	maxVersion := uint64(0)
+	// Mainnet blocks contain versioned (v0, and v1 once SIMD-0385 is
+	// active) transactions; GetBlock requires MaxSupportedTransactionVersion
+	// or it errors out.
+	maxVersion := rpc.MaxSupportedTransactionVersion1
 
 	{
 		out, err := client.GetBlockWithOpts(ctx, slot, &rpc.GetBlockOpts{

--- a/rpc/examples/getTransaction/getTransaction.go
+++ b/rpc/examples/getTransaction/getTransaction.go
@@ -46,7 +46,9 @@ func main() {
 	txSig := sigs[0].Signature
 	fmt.Println("fetching tx:", txSig)
 
-	maxVersion := uint64(0)
+	// Ask for the newest transaction format we can decode (v1 / SIMD-0385
+	// includes v0 and legacy).
+	maxVersion := rpc.MaxSupportedTransactionVersion1
 	{
 		out, err := client.GetTransaction(
 			ctx,
@@ -58,6 +60,8 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
+		// -1 (legacy), 0 (v0) or 1 (v1).
+		fmt.Println("transaction version:", out.Version)
 		spew.Dump(out)
 		spew.Dump(out.Transaction.GetTransaction())
 	}

--- a/rpc/examples/sendTransactionV1/sendTransactionV1.go
+++ b/rpc/examples/sendTransactionV1/sendTransactionV1.go
@@ -1,0 +1,103 @@
+// Copyright 2026 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/programs/system"
+	"github.com/gagliardetto/solana-go/rpc"
+)
+
+// Builds, signs and submits a v1 (SIMD-0385) transaction on devnet.
+// v1: 4096-byte cap, inline compute budget, no address lookup tables.
+// The cluster must have SIMD-0385 activated. See also `sendTransaction`.
+func main() {
+	ctx := context.Background()
+	client := rpc.New(rpc.DevNet_RPC)
+
+	// Fresh funded sender; real code loads a keypair (PrivateKeyFromSolanaKeygenFile).
+	sender := solana.NewWallet()
+	fmt.Println("sender:", sender.PublicKey())
+
+	airdropSig, err := client.RequestAirdrop(
+		ctx,
+		sender.PublicKey(),
+		solana.LAMPORTS_PER_SOL,
+		rpc.CommitmentFinalized,
+	)
+	if err != nil {
+		panic(fmt.Errorf("airdrop: %w", err))
+	}
+	fmt.Println("airdrop signature:", airdropSig)
+	time.Sleep(20 * time.Second) // wait for the airdrop to finalize
+
+	recipient := solana.NewWallet().PublicKey()
+
+	recent, err := client.GetLatestBlockhash(ctx, rpc.CommitmentFinalized)
+	if err != nil {
+		panic(fmt.Errorf("get blockhash: %w", err))
+	}
+
+	// Inline compute budget: unset CU limit means 0; PriorityFee is total lamports.
+	config := solana.TransactionConfig{}.
+		WithComputeUnitLimit(20_000).
+		WithPriorityFee(1_000)
+
+	tx, err := solana.NewTransaction(
+		[]solana.Instruction{
+			system.NewTransferInstruction(
+				solana.LAMPORTS_PER_SOL/1000, // 0.001 SOL
+				sender.PublicKey(),
+				recipient,
+			).Build(),
+		},
+		recent.Value.Blockhash,
+		solana.TransactionPayer(sender.PublicKey()),
+		// Selects the V1 message format and embeds the compute budget.
+		solana.TransactionV1Config(config),
+	)
+	if err != nil {
+		panic(fmt.Errorf("build tx: %w", err))
+	}
+	fmt.Println("message version is v1:", tx.Message.GetVersion() == solana.MessageVersionV1)
+
+	if _, err := tx.Sign(func(key solana.PublicKey) *solana.PrivateKey {
+		if sender.PublicKey().Equals(key) {
+			return &sender.PrivateKey
+		}
+		return nil
+	}); err != nil {
+		panic(fmt.Errorf("sign: %w", err))
+	}
+
+	wire, err := tx.MarshalBinary()
+	if err != nil {
+		panic(fmt.Errorf("serialize: %w", err))
+	}
+	fmt.Printf("serialized size: %d bytes (max %d)\n", len(wire), solana.MaxTransactionSizeV1)
+
+	sig, err := client.SendTransaction(ctx, tx)
+	if err != nil {
+		panic(fmt.Errorf("send: %w", err))
+	}
+
+	fmt.Println("submitted tx signature:", sig.String())
+
+	// Fetch it back with MaxSupportedTransactionVersion: &rpc.MaxSupportedTransactionVersion1.
+}

--- a/rpc/transaction_v1_test.go
+++ b/rpc/transaction_v1_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpc
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"testing"
+
+	"github.com/gagliardetto/solana-go"
+	stdjson "github.com/goccy/go-json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// V1 (SIMD-0385) transaction produced by the Rust SDK; same vector as
+// `v1GoldenTxFeeHeap` in the root package.
+const v1GoldenTxFeeHeapHex = "8101000113000000070707070707070707070707070707070707070707070707070707070707070701028a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c1010101010101010101010101010101010101010101010101010101010101010010000000000000000800000010100000070083fb1bf5a9e2c90c6903b7328529cdf59e04e2fcf29c718bea8c76fd325f4b67e18feb1f95f9aab171140b81b8c8238c9ffea33d4133bae92af68c6453800"
+
+// A base64 getTransaction envelope holding a v1 tx decodes as v1.
+func TestTransactionResultEnvelope_V1Base64(t *testing.T) {
+	raw, err := hex.DecodeString(v1GoldenTxFeeHeapHex)
+	require.NoError(t, err)
+	in := `["` + base64.StdEncoding.EncodeToString(raw) + `","base64"]`
+
+	var env TransactionResultEnvelope
+	require.NoError(t, env.UnmarshalJSON([]byte(in)))
+	assert.Equal(t, raw, env.GetBinary())
+
+	tx, err := env.GetTransaction()
+	require.NoError(t, err)
+	require.NotNil(t, tx)
+	assert.Equal(t, solana.MessageVersionV1, tx.Message.GetVersion())
+	require.NotNil(t, tx.Message.TransactionConfig.PriorityFee)
+	assert.Equal(t, uint64(1), *tx.Message.TransactionConfig.PriorityFee)
+	require.NotNil(t, tx.Message.TransactionConfig.HeapSize)
+	assert.Equal(t, uint32(32768), *tx.Message.TransactionConfig.HeapSize)
+	require.NoError(t, tx.VerifySignatures())
+
+	// TransactionWithMeta binary path.
+	twm := TransactionWithMeta{}
+	require.NoError(t, stdjson.Unmarshal([]byte(`{"transaction":`+in+`,"version":1}`), &twm))
+	assert.Equal(t, TransactionVersion(1), twm.Version)
+	tx2, err := twm.GetTransaction()
+	require.NoError(t, err)
+	assert.Equal(t, solana.MessageVersionV1, tx2.Message.GetVersion())
+}
+
+// The `json` encoding of a V1 transaction (agave UiRawMessage) carries
+// `transactionConfig` and no `addressTableLookups`.
+func TestTransactionResultEnvelope_V1JSON(t *testing.T) {
+	in := `{
+		"signatures": ["3Euy3SsYzpQ4EvwX4qvVui1YcNAwdDGinuTVhMxvy92NzWDYnNMeacmv4wEmPJndGz6tsX7VSLHFJFawFzQh12b9"],
+		"message": {
+			"header": {"numRequiredSignatures":1,"numReadonlySignedAccounts":0,"numReadonlyUnsignedAccounts":1},
+			"accountKeys": ["AKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9","25hjHpTATmkdET17ynDhf1MCuYNDn1z7wXfVw5iaxLAK"],
+			"recentBlockhash": "US517G5965aydkZ46HS38QLi7UQiSojurfbQfKCELFx",
+			"instructions": [{"programIdIndex":1,"accounts":[0],"data":"","stackHeight":null}],
+			"transactionConfig": {"priorityFee":1,"computeUnitLimit":null,"loadedAccountsDataSizeLimit":null,"heapSize":32768}
+		}
+	}`
+	var env TransactionResultEnvelope
+	require.NoError(t, env.UnmarshalJSON([]byte(in)))
+	tx, err := env.GetTransaction()
+	require.NoError(t, err)
+	require.NotNil(t, tx)
+	assert.Equal(t, solana.MessageVersionV1, tx.Message.GetVersion())
+	assert.Nil(t, tx.Message.AddressTableLookups)
+	require.NotNil(t, tx.Message.TransactionConfig.PriorityFee)
+	assert.Equal(t, uint64(1), *tx.Message.TransactionConfig.PriorityFee)
+	assert.Nil(t, tx.Message.TransactionConfig.ComputeUnitLimit)
+	require.NotNil(t, tx.Message.TransactionConfig.HeapSize)
+	assert.Equal(t, uint32(32768), *tx.Message.TransactionConfig.HeapSize)
+
+	// Same tx as the binary golden vector: re-encodes identically, signature verifies.
+	raw, err := hex.DecodeString(v1GoldenTxFeeHeapHex)
+	require.NoError(t, err)
+	again, err := tx.MarshalBinary()
+	require.NoError(t, err)
+	assert.Equal(t, raw, again)
+	require.NoError(t, tx.VerifySignatures())
+}
+
+// jsonParsed: ParsedMessage exposes transactionConfig for V1 transactions
+// and leaves it nil otherwise.
+func TestParsedMessage_TransactionConfig(t *testing.T) {
+	v1 := `{
+		"accountKeys": [{"pubkey":"AKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9","signer":true,"writable":true,"source":"transaction"}],
+		"recentBlockhash": "US517G5965aydkZ46HS38QLi7UQiSojurfbQfKCELFx",
+		"instructions": [],
+		"transactionConfig": {"priorityFee":5000,"computeUnitLimit":200000,"loadedAccountsDataSizeLimit":null,"heapSize":null}
+	}`
+	var pm ParsedMessage
+	require.NoError(t, stdjson.Unmarshal([]byte(v1), &pm))
+	require.NotNil(t, pm.TransactionConfig)
+	assert.Equal(t, uint64(5000), *pm.TransactionConfig.PriorityFee)
+	assert.Equal(t, uint32(200000), *pm.TransactionConfig.ComputeUnitLimit)
+	assert.Nil(t, pm.TransactionConfig.LoadedAccountsDataSizeLimit)
+	assert.Nil(t, pm.TransactionConfig.HeapSize)
+
+	legacy := `{"accountKeys":[],"recentBlockhash":"US517G5965aydkZ46HS38QLi7UQiSojurfbQfKCELFx","instructions":[]}`
+	var pm2 ParsedMessage
+	require.NoError(t, stdjson.Unmarshal([]byte(legacy), &pm2))
+	assert.Nil(t, pm2.TransactionConfig)
+
+	// Round-trip keeps the config, and omits it when nil.
+	out, err := stdjson.Marshal(pm)
+	require.NoError(t, err)
+	assert.Contains(t, string(out), `"transactionConfig":{"priorityFee":5000`)
+	out2, err := stdjson.Marshal(pm2)
+	require.NoError(t, err)
+	assert.NotContains(t, string(out2), "transactionConfig")
+}

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -586,6 +586,10 @@ type ParsedMessage struct {
 	AccountKeys     []ParsedMessageAccount `json:"accountKeys"`
 	Instructions    []*ParsedInstruction   `json:"instructions"`
 	RecentBlockHash string                 `json:"recentBlockhash"`
+
+	// Inline compute budget configuration; only present for v1 (SIMD-0385)
+	// transactions.
+	TransactionConfig *solana.TransactionConfig `json:"transactionConfig,omitempty"`
 }
 
 type ParsedInstruction struct {

--- a/sanitize.go
+++ b/sanitize.go
@@ -29,60 +29,64 @@ func IsSanitizeError(err error) bool {
 const maxAccountKeys = 256
 
 // Sanitize validates the structural integrity of a Message.
-// Ported from solana-sdk/message: legacy.rs sanitize() and v0/mod.rs sanitize().
+// Ported from solana-sdk/message legacy.rs, v0/mod.rs sanitize() and v1 validate().
 func (m *Message) Sanitize() error {
-	if m.IsVersioned() {
+	switch m.version {
+	case MessageVersionV1:
+		return m.sanitizeV1()
+	case MessageVersionV0:
 		return m.sanitizeV0()
+	default:
+		return m.sanitizeLegacy()
 	}
-	return m.sanitizeLegacy()
 }
 
-func (m *Message) sanitizeLegacy() error {
-	numKeys := len(m.AccountKeys)
-
+// sanitizeHeader checks the header against the number of static keys.
+func (m *Message) sanitizeHeader(numStaticKeys int, keysLabel string) error {
 	// Signing area and read-only non-signing area should not overlap.
-	if int(m.Header.NumRequiredSignatures)+int(m.Header.NumReadonlyUnsignedAccounts) > numKeys {
-		return newSanitizeError("header references more accounts than available: required_signatures(%d) + readonly_unsigned(%d) > account_keys(%d)",
-			m.Header.NumRequiredSignatures, m.Header.NumReadonlyUnsignedAccounts, numKeys)
+	if int(m.Header.NumRequiredSignatures)+int(m.Header.NumReadonlyUnsignedAccounts) > numStaticKeys {
+		return newSanitizeError("header references more accounts than available: required_signatures(%d) + readonly_unsigned(%d) > %s(%d)",
+			m.Header.NumRequiredSignatures, m.Header.NumReadonlyUnsignedAccounts, keysLabel, numStaticKeys)
 	}
-
 	// There should be at least 1 RW fee-payer account.
 	if m.Header.NumReadonlySignedAccounts >= m.Header.NumRequiredSignatures {
 		return newSanitizeError("no writable signer: readonly_signed(%d) >= required_signatures(%d)",
 			m.Header.NumReadonlySignedAccounts, m.Header.NumRequiredSignatures)
 	}
+	return nil
+}
 
+// sanitizeInstructions checks program and account indices against the given bounds.
+func (m *Message) sanitizeInstructions(maxProgramIdx, maxAccountIdx int, programErr string) error {
 	for i, ci := range m.Instructions {
-		if int(ci.ProgramIDIndex) >= numKeys {
-			return newSanitizeError("instruction %d: program_id_index %d out of bounds (account_keys len %d)", i, ci.ProgramIDIndex, numKeys)
+		if int(ci.ProgramIDIndex) > maxProgramIdx {
+			return newSanitizeError("instruction %d: program_id_index %d "+programErr, i, ci.ProgramIDIndex, maxProgramIdx)
 		}
 		// A program cannot be the payer.
 		if ci.ProgramIDIndex == 0 {
 			return newSanitizeError("instruction %d: program_id_index cannot be 0 (fee payer)", i)
 		}
 		for _, ai := range ci.Accounts {
-			if int(ai) >= numKeys {
-				return newSanitizeError("instruction %d: account index %d out of bounds (account_keys len %d)", i, ai, numKeys)
+			if int(ai) > maxAccountIdx {
+				return newSanitizeError("instruction %d: account index %d out of bounds (max %d)", i, ai, maxAccountIdx)
 			}
 		}
 	}
-
 	return nil
+}
+
+func (m *Message) sanitizeLegacy() error {
+	numKeys := len(m.AccountKeys)
+	if err := m.sanitizeHeader(numKeys, "account_keys"); err != nil {
+		return err
+	}
+	return m.sanitizeInstructions(numKeys-1, numKeys-1, "out of bounds (max %d)")
 }
 
 func (m *Message) sanitizeV0() error {
 	numStaticKeys := len(m.AccountKeys)
-
-	// Signing area and read-only non-signing area should not overlap.
-	if int(m.Header.NumRequiredSignatures)+int(m.Header.NumReadonlyUnsignedAccounts) > numStaticKeys {
-		return newSanitizeError("header references more accounts than available: required_signatures(%d) + readonly_unsigned(%d) > static_keys(%d)",
-			m.Header.NumRequiredSignatures, m.Header.NumReadonlyUnsignedAccounts, numStaticKeys)
-	}
-
-	// There should be at least 1 RW fee-payer account.
-	if m.Header.NumReadonlySignedAccounts >= m.Header.NumRequiredSignatures {
-		return newSanitizeError("no writable signer: readonly_signed(%d) >= required_signatures(%d)",
-			m.Header.NumReadonlySignedAccounts, m.Header.NumRequiredSignatures)
+	if err := m.sanitizeHeader(numStaticKeys, "static_keys"); err != nil {
+		return err
 	}
 
 	// Count dynamic keys from address table lookups.
@@ -107,26 +111,53 @@ func (m *Message) sanitizeV0() error {
 		return newSanitizeError("total account keys %d exceeds maximum %d", totalKeys, maxAccountKeys)
 	}
 
-	maxAccountIdx := totalKeys - 1
 	// Program IDs must be in static keys only (not from lookup tables).
-	maxProgramIdx := numStaticKeys - 1
+	return m.sanitizeInstructions(numStaticKeys-1, totalKeys-1, "exceeds static keys (max %d)")
+}
 
-	for i, ci := range m.Instructions {
-		if int(ci.ProgramIDIndex) > maxProgramIdx {
-			return newSanitizeError("instruction %d: program_id_index %d exceeds static keys (max %d)", i, ci.ProgramIDIndex, maxProgramIdx)
+// sanitizeV1 validates a V1 (SIMD-0385) message.
+// Ported from solana-sdk message/src/versions/v1/message.rs validate() (+ #699 heap bounds).
+func (m *Message) sanitizeV1() error {
+	if len(m.AddressTableLookups) > 0 {
+		return newSanitizeError("v1 messages do not support address table lookups (got %d)", len(m.AddressTableLookups))
+	}
+	if int(m.Header.NumRequiredSignatures) > MaxSignaturesV1 {
+		return newSanitizeError("too many signatures: required_signatures(%d) > max %d", m.Header.NumRequiredSignatures, MaxSignaturesV1)
+	}
+	if len(m.Instructions) > MaxInstructionsV1 {
+		return newSanitizeError("too many instructions: %d > max %d", len(m.Instructions), MaxInstructionsV1)
+	}
+	numKeys := len(m.AccountKeys)
+	if numKeys > MaxAddressesV1 {
+		return newSanitizeError("too many addresses: %d > max %d", numKeys, MaxAddressesV1)
+	}
+	if err := m.sanitizeHeader(numKeys, "account_keys"); err != nil {
+		return err
+	}
+	if m.HasDuplicates() {
+		return newSanitizeError("duplicate addresses found in message")
+	}
+	// Invalid mask bits only exist on the wire and are rejected by UnmarshalV1.
+	if hs := m.TransactionConfig.HeapSize; hs != nil {
+		if *hs%1024 != 0 {
+			return newSanitizeError("heap size %d is not a multiple of 1024", *hs)
 		}
-		// A program cannot be the payer.
-		if ci.ProgramIDIndex == 0 {
-			return newSanitizeError("instruction %d: program_id_index cannot be 0 (fee payer)", i)
-		}
-		for _, ai := range ci.Accounts {
-			if int(ai) > maxAccountIdx {
-				return newSanitizeError("instruction %d: account index %d out of bounds (max %d)", i, ai, maxAccountIdx)
-			}
+		if *hs < MinHeapSizeV1 || *hs > MaxHeapSizeV1 {
+			return newSanitizeError("heap size %d out of bounds [%d, %d]", *hs, MinHeapSizeV1, MaxHeapSizeV1)
 		}
 	}
-
-	return nil
+	if numKeys == 0 {
+		return newSanitizeError("message has no account keys")
+	}
+	for i, ci := range m.Instructions {
+		if len(ci.Accounts) > 255 {
+			return newSanitizeError("instruction %d: too many accounts (%d), max 255", i, len(ci.Accounts))
+		}
+		if len(ci.Data) > 65535 {
+			return newSanitizeError("instruction %d: data too large (%d bytes), max 65535", i, len(ci.Data))
+		}
+	}
+	return m.sanitizeInstructions(numKeys-1, numKeys-1, "out of bounds (max %d)")
 }
 
 // HasDuplicates checks if the message has duplicate account keys.

--- a/transaction.go
+++ b/transaction.go
@@ -36,6 +36,7 @@ type Transaction struct {
 	// The list is always of length `message.header.numRequiredSignatures` and not empty.
 	// The signature at index `i` corresponds to the public key at index
 	// `i` in `message.account_keys`. The first one is used as the transaction id.
+	// Wire: legacy/v0 = compact-u16 count + sigs + message; v1 = message + sigs.
 	Signatures []Signature `json:"signatures"`
 
 	// Defines the content of the transaction.
@@ -164,6 +165,8 @@ type TransactionOption interface {
 type transactionOptions struct {
 	payer         PublicKey
 	addressTables map[PublicKey]PublicKeySlice // [tablePubkey]addresses
+	version       MessageVersion               // requested message version; zero value = auto (legacy, or v0 if lookups are used)
+	config        TransactionConfig            // v1 only
 }
 
 type transactionOptionFunc func(opts *transactionOptions)
@@ -178,6 +181,20 @@ func TransactionPayer(payer PublicKey) TransactionOption {
 
 func TransactionAddressTables(tables map[PublicKey]PublicKeySlice) TransactionOption {
 	return transactionOptionFunc(func(opts *transactionOptions) { opts.addressTables = tables })
+}
+
+// TransactionMessageVersion selects the message version built by NewTransaction.
+// V1 rejects address tables and ComputeBudget instructions; prefer TransactionV1Config.
+func TransactionMessageVersion(version MessageVersion) TransactionOption {
+	return transactionOptionFunc(func(opts *transactionOptions) { opts.version = version })
+}
+
+// TransactionV1Config sets the v1 inline compute budget and implies MessageVersionV1.
+func TransactionV1Config(config TransactionConfig) TransactionOption {
+	return transactionOptionFunc(func(opts *transactionOptions) {
+		opts.config = config
+		opts.version = MessageVersionV1
+	})
 }
 
 var debugNewTransaction = false
@@ -218,6 +235,18 @@ func (builder *TransactionBuilder) SetFeePayer(feePayer PublicKey) *TransactionB
 	return builder
 }
 
+// SetVersion selects the message version (see TransactionMessageVersion).
+func (builder *TransactionBuilder) SetVersion(version MessageVersion) *TransactionBuilder {
+	builder.opts = append(builder.opts, TransactionMessageVersion(version))
+	return builder
+}
+
+// SetTransactionConfig sets the v1 inline compute budget (see TransactionV1Config).
+func (builder *TransactionBuilder) SetTransactionConfig(config TransactionConfig) *TransactionBuilder {
+	builder.opts = append(builder.opts, TransactionV1Config(config))
+	return builder
+}
+
 // Build builds and returns a *Transaction.
 func (builder *TransactionBuilder) Build() (*Transaction, error) {
 	return NewTransaction(
@@ -240,6 +269,24 @@ func NewTransaction(instructions []Instruction, recentBlockHash Hash, opts ...Tr
 	options := transactionOptions{}
 	for _, opt := range opts {
 		opt.apply(&options)
+	}
+
+	switch options.version {
+	case MessageVersionLegacy, MessageVersionV0:
+		if !options.config.IsEmpty() {
+			return nil, fmt.Errorf("TransactionV1Config requires MessageVersionV1 (got version %d)", options.version)
+		}
+	case MessageVersionV1:
+		if len(options.addressTables) > 0 {
+			return nil, fmt.Errorf("v1 transactions do not support address lookup tables; drop TransactionAddressTables or use v0")
+		}
+		for i, ix := range instructions {
+			if ix.ProgramID().Equals(ComputeBudget) {
+				return nil, fmt.Errorf("instruction %d: ComputeBudget instructions are no-ops in v1 transactions; use TransactionV1Config", i)
+			}
+		}
+	default:
+		return nil, fmt.Errorf("invalid message version: %d", options.version)
 	}
 
 	feePayer := options.payer
@@ -514,6 +561,18 @@ func NewTransaction(instructions []Instruction, recentBlockHash Hash, opts ...Tr
 		})
 	}
 
+	switch options.version {
+	case MessageVersionV0:
+		message.version = MessageVersionV0
+	case MessageVersionV1:
+		message.version = MessageVersionV1
+		message.TransactionConfig = options.config
+		// Fail early on the SIMD-0385 structural limits.
+		if err := message.sanitizeV1(); err != nil {
+			return nil, fmt.Errorf("v1 transaction: %w", err)
+		}
+	}
+
 	return &Transaction{
 		Message: message,
 	}, nil
@@ -533,6 +592,19 @@ func (tx *Transaction) MarshalBinary() ([]byte, error) {
 		// the serialized transaction will be invalid.
 		// reference: https://github.com/solana-labs/solana-web3.js/blob/4e9988cfc561f3ed11f4c5016a29090a61d129a8/src/transaction/versioned.ts#L36
 		signatures = append(signatures, make([]Signature, missing)...)
+	}
+
+	if tx.Message.version == MessageVersionV1 {
+		// V1: prefixed message, then exactly numRequiredSignatures signatures.
+		if numRequired := int(tx.Message.Header.NumRequiredSignatures); len(signatures) > numRequired {
+			return nil, fmt.Errorf("v1 transaction: %d signatures but header requires %d (the v1 wire format has no signature count)", len(signatures), numRequired)
+		}
+		binaryTx := make([]byte, 0, len(messageContent)+len(signatures)*64)
+		binaryTx = append(binaryTx, messageContent...)
+		for _, sig := range signatures {
+			binaryTx = append(binaryTx, sig[:]...)
+		}
+		return binaryTx, nil
 	}
 
 	var signaturesCountBytes []byte
@@ -557,6 +629,17 @@ func (tx Transaction) MarshalWithEncoder(encoder *bin.Encoder) error {
 }
 
 func (tx *Transaction) UnmarshalWithDecoder(decoder *bin.Decoder) (err error) {
+	// First byte: compact-u16 signature count (< 0x80) for legacy/v0, 0x81 for v1.
+	first, err := decoder.Peek(1)
+	if err != nil {
+		return fmt.Errorf("unable to peek transaction discriminator: %w", err)
+	}
+	if first[0] == messageVersionV1Prefix {
+		return tx.unmarshalV1(decoder)
+	}
+	if first[0]&messageVersionPrefix != 0 {
+		return fmt.Errorf("invalid transaction discriminator: 0x%02x", first[0])
+	}
 	{
 		numSignatures, err := decoder.ReadCompactU16()
 		if err != nil {
@@ -578,6 +661,31 @@ func (tx *Transaction) UnmarshalWithDecoder(decoder *bin.Decoder) (err error) {
 		err := tx.Message.UnmarshalWithDecoder(decoder)
 		if err != nil {
 			return fmt.Errorf("unable to decode tx.Message: %w", err)
+		}
+		// v1 message in a legacy/v0 envelope is malformed (upstream #566).
+		if tx.Message.version == MessageVersionV1 {
+			return fmt.Errorf("invalid message version: v1 message in a legacy/v0 transaction envelope")
+		}
+	}
+	return nil
+}
+
+// unmarshalV1 decodes a v1 transaction: message, then numRequiredSignatures signatures.
+func (tx *Transaction) unmarshalV1(decoder *bin.Decoder) error {
+	if err := tx.Message.UnmarshalV1(decoder); err != nil {
+		return fmt.Errorf("unable to decode tx.Message: %w", err)
+	}
+	numSignatures := int(tx.Message.Header.NumRequiredSignatures)
+	if numSignatures > len(tx.Message.AccountKeys) {
+		return fmt.Errorf("v1 transaction: header requires %d signatures but only %d account keys", numSignatures, len(tx.Message.AccountKeys))
+	}
+	if numSignatures*64 > decoder.Remaining() {
+		return fmt.Errorf("v1 transaction: header requires %d signatures (%d bytes) but only %d bytes remain", numSignatures, numSignatures*64, decoder.Remaining())
+	}
+	tx.Signatures = make([]Signature, numSignatures)
+	for i := range tx.Signatures {
+		if _, err := decoder.Read(tx.Signatures[i][:]); err != nil {
+			return fmt.Errorf("unable to read tx.Signatures[%d]: %w", i, err)
 		}
 	}
 	return nil

--- a/transaction.go
+++ b/transaction.go
@@ -88,9 +88,19 @@ func TransactionFromDecoder(decoder *bin.Decoder) (*Transaction, error) {
 	return out, nil
 }
 
+// TransactionFromBytes decodes a transaction from the whole slice.
+// For v1, trailing bytes are rejected (SIMD-0385); legacy/v0 stay lenient.
+// Streaming callers can use TransactionFromDecoder, which is always lenient.
 func TransactionFromBytes(data []byte) (*Transaction, error) {
 	decoder := bin.NewBinDecoder(data)
-	return TransactionFromDecoder(decoder)
+	tx, err := TransactionFromDecoder(decoder)
+	if err != nil {
+		return nil, err
+	}
+	if tx.Message.version == MessageVersionV1 && decoder.Remaining() > 0 {
+		return nil, fmt.Errorf("v1 transaction: %d trailing bytes after signatures", decoder.Remaining())
+	}
+	return tx, nil
 }
 
 func TransactionFromBase64(b64 string) (*Transaction, error) {

--- a/transaction_v1_test.go
+++ b/transaction_v1_test.go
@@ -1,0 +1,660 @@
+package solana
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"testing"
+
+	bin "github.com/gagliardetto/binary"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Ported from solana-sdk transaction/src/versioned/mod.rs and sanitized.rs (v1 parts).
+
+// Golden v1 transactions from the Rust SDK; signer seeds [1;32] and [2;32].
+const (
+	// (a) empty config, 1 signer, 1 instruction
+	v1GoldenTxEmptyConfig = "8101000200000000abababababababababababababababababababababababababababababababab01048a88e3dd7409" +
+		"f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c02020202020202020202020202020202020202020202" +
+		"020202020202020202020303030303030303030303030303030303030303030303030303030303030303101010101010" +
+		"101010101010101010101010101010101010101010101010101003030400000102deadbeef4e72ba5d7f993321339fd3" +
+		"511742c1c21f5b80ca529337413f766a32485b86ddc124f38ebe5f3a907ed3ede52331e746c7e55fddefae148c5aea7a" +
+		"780af4b604"
+
+	// (b) all four config fields, 2 signers (one readonly), 3 instructions (one with empty data)
+	v1GoldenTxFullConfig = "810201031f000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb03068a88e3dd7409" +
+		"f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c8139770ea87d175f56a35466c34c7ecccb8d8a91b4ee" +
+		"37a25df60f5b8fc9b3940404040404040404040404040404040404040404040404040404040404040404050505050505" +
+		"050505050505050505050505050505050505050505050505050510101010101010101010101010101010101010101010" +
+		"101010101010101010102020202020202020202020202020202020202020202020202020202020202020881300000000" +
+		"0000400d03000000010000000100040303000501000004002c0100010201020303000102030405060708090a0b0c0d0e" +
+		"0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e" +
+		"3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e" +
+		"6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e" +
+		"9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdce" +
+		"cfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfe" +
+		"ff000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2bf24e03" +
+		"afc6235e9892eefba1956ccc9fb2b88cbd8dc8bd8680ca858655c0400e9059af3a76b3c2aab2f2c52c4169eb2c21db5a" +
+		"4f3e31fb9fc056290bc97162079c370ae9e55f2f6a0c1ef654558900295e253bbec40644a6a1c5e49c9b66eb7d3e8b51" +
+		"596f5059c82e1cfa680ffcc7572e962b0113dfde0dcd2eaefbdf86c003"
+
+	// (c) priority fee + heap size only, empty instruction data
+	v1GoldenTxFeeHeap = "8101000113000000070707070707070707070707070707070707070707070707070707070707070701028a88e3dd7409" +
+		"f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c10101010101010101010101010101010101010101010" +
+		"10101010101010101010010000000000000000800000010100000070083fb1bf5a9e2c90c6903b7328529cdf59e04e2f" +
+		"cf29c718bea8c76fd325f4b67e18feb1f95f9aab171140b81b8c8238c9ffea33d4133bae92af68c6453800"
+)
+
+var (
+	v1TestPayerKey   = PrivateKey(ed25519.NewKeyFromSeed(bytesRepeat(1, 32)))
+	v1TestSigner2Key = PrivateKey(ed25519.NewKeyFromSeed(bytesRepeat(2, 32)))
+)
+
+func bytesRepeat(b byte, n int) []byte {
+	out := make([]byte, n)
+	for i := range out {
+		out[i] = b
+	}
+	return out
+}
+
+func pubkeyRepeat(b byte) PublicKey {
+	var pk PublicKey
+	copy(pk[:], bytesRepeat(b, 32))
+	return pk
+}
+
+func hashRepeat(b byte) Hash {
+	var h Hash
+	copy(h[:], bytesRepeat(b, 32))
+	return h
+}
+
+func mustHex(t *testing.T, s string) []byte {
+	t.Helper()
+	out, err := hex.DecodeString(s)
+	require.NoError(t, err)
+	return out
+}
+
+func v1TestSigner(t *testing.T, keys ...PrivateKey) privateKeyGetter {
+	t.Helper()
+	return func(pub PublicKey) *PrivateKey {
+		for i := range keys {
+			if keys[i].PublicKey().Equals(pub) {
+				return &keys[i]
+			}
+		}
+		return nil
+	}
+}
+
+func TestV1_TestKeysMatchRustGenerator(t *testing.T) {
+	assert.Equal(t, "AKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9", v1TestPayerKey.PublicKey().String())
+	assert.Equal(t, "9hSR6S7WPtxmTojgo6GG3k4yDPecgJY292j7xrsUGWBu", v1TestSigner2Key.PublicKey().String())
+}
+
+// The Rust-produced transactions must decode, verify, sanitize and re-encode
+// byte-for-byte.
+func TestV1_GoldenTransactionsFromRustSDK(t *testing.T) {
+	type expect struct {
+		name      string
+		hex       string
+		header    MessageHeader
+		numKeys   int
+		numIx     int
+		config    TransactionConfig
+		signers   []PrivateKey
+		blockhash Hash
+	}
+	cases := []expect{
+		{
+			name:      "a_empty_config",
+			hex:       v1GoldenTxEmptyConfig,
+			header:    MessageHeader{NumRequiredSignatures: 1, NumReadonlySignedAccounts: 0, NumReadonlyUnsignedAccounts: 2},
+			numKeys:   4,
+			numIx:     1,
+			config:    TransactionConfig{},
+			signers:   []PrivateKey{v1TestPayerKey},
+			blockhash: hashRepeat(0xAB),
+		},
+		{
+			name:    "b_full_config",
+			hex:     v1GoldenTxFullConfig,
+			header:  MessageHeader{NumRequiredSignatures: 2, NumReadonlySignedAccounts: 1, NumReadonlyUnsignedAccounts: 3},
+			numKeys: 6,
+			numIx:   3,
+			config: TransactionConfig{}.
+				WithPriorityFee(5000).
+				WithComputeUnitLimit(200_000).
+				WithLoadedAccountsDataSizeLimit(65_536).
+				WithHeapSize(65_536),
+			signers:   []PrivateKey{v1TestPayerKey, v1TestSigner2Key},
+			blockhash: hashRepeat(0xBB),
+		},
+		{
+			name:      "c_fee_heap",
+			hex:       v1GoldenTxFeeHeap,
+			header:    MessageHeader{NumRequiredSignatures: 1, NumReadonlySignedAccounts: 0, NumReadonlyUnsignedAccounts: 1},
+			numKeys:   2,
+			numIx:     1,
+			config:    TransactionConfig{}.WithPriorityFee(1).WithHeapSize(32_768),
+			signers:   []PrivateKey{v1TestPayerKey},
+			blockhash: hashRepeat(7),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw := mustHex(t, tc.hex)
+			require.LessOrEqual(t, len(raw), MaxTransactionSizeV1)
+
+			tx, err := TransactionFromBytes(raw)
+			require.NoError(t, err)
+			assert.Equal(t, MessageVersionV1, tx.Message.GetVersion())
+			assert.Equal(t, tc.header, tx.Message.Header)
+			assert.Len(t, tx.Message.AccountKeys, tc.numKeys)
+			assert.Len(t, tx.Message.Instructions, tc.numIx)
+			assert.Equal(t, tc.config, tx.Message.TransactionConfig)
+			assert.Equal(t, tc.blockhash, tx.Message.RecentBlockhash)
+			assert.Nil(t, tx.Message.AddressTableLookups)
+			require.Len(t, tx.Signatures, int(tc.header.NumRequiredSignatures))
+			for i, k := range tc.signers {
+				assert.Equal(t, k.PublicKey(), tx.Message.AccountKeys[i], "signer %d", i)
+			}
+
+			// Rust signatures verify against the Go message bytes (0x81 included).
+			require.NoError(t, tx.VerifySignatures())
+			require.NoError(t, tx.Sanitize())
+			results, err := tx.VerifyWithResults()
+			require.NoError(t, err)
+			for _, ok := range results {
+				assert.True(t, ok)
+			}
+
+			// Byte-exact re-encode.
+			again, err := tx.MarshalBinary()
+			require.NoError(t, err)
+			assert.Equal(t, raw, again)
+
+			// Deterministic ed25519: re-signing reproduces the Rust signatures.
+			resigned := *tx
+			resigned.Signatures = nil
+			_, err = resigned.Sign(v1TestSigner(t, tc.signers...))
+			require.NoError(t, err)
+			assert.Equal(t, tx.Signatures, resigned.Signatures)
+
+			// Base64 / base58 helpers.
+			b64, err := tx.ToBase64()
+			require.NoError(t, err)
+			fromB64, err := TransactionFromBase64(b64)
+			require.NoError(t, err)
+			assert.Equal(t, MessageVersionV1, fromB64.Message.GetVersion())
+			assert.Equal(t, tx.Signatures, fromB64.Signatures)
+
+			// The tree renderer must not panic on V1.
+			assert.NotEmpty(t, tx.String())
+		})
+	}
+}
+
+// NewTransaction must reproduce Rust try_compile_with_config byte-for-byte.
+func TestV1_NewTransactionMatchesRustSDK(t *testing.T) {
+	payer := v1TestPayerKey.PublicKey()
+	s2 := v1TestSigner2Key.PublicKey()
+	p1 := pubkeyRepeat(0x10)
+	p2 := pubkeyRepeat(0x20)
+
+	t.Run("a_empty_config", func(t *testing.T) {
+		ix := NewInstruction(p1, AccountMetaSlice{
+			Meta(payer).WRITE().SIGNER(),
+			Meta(pubkeyRepeat(0x02)).WRITE(),
+			Meta(pubkeyRepeat(0x03)),
+		}, []byte{0xDE, 0xAD, 0xBE, 0xEF})
+		tx, err := NewTransaction([]Instruction{ix}, hashRepeat(0xAB),
+			TransactionPayer(payer),
+			TransactionMessageVersion(MessageVersionV1),
+		)
+		require.NoError(t, err)
+		_, err = tx.Sign(v1TestSigner(t, v1TestPayerKey))
+		require.NoError(t, err)
+		got, err := tx.MarshalBinary()
+		require.NoError(t, err)
+		assert.Equal(t, mustHex(t, v1GoldenTxEmptyConfig), got)
+	})
+
+	t.Run("b_full_config", func(t *testing.T) {
+		ix1 := NewInstruction(p1, AccountMetaSlice{
+			Meta(payer).WRITE().SIGNER(),
+			Meta(s2).SIGNER(),
+			Meta(pubkeyRepeat(0x04)).WRITE(),
+		}, []byte{1, 2, 3})
+		ix2 := NewInstruction(p2, AccountMetaSlice{Meta(pubkeyRepeat(0x05))}, []byte{})
+		data3 := make([]byte, 300)
+		for i := range data3 {
+			data3[i] = byte(i % 256)
+		}
+		ix3 := NewInstruction(p1, AccountMetaSlice{}, data3)
+		cfg := TransactionConfig{}.
+			WithPriorityFee(5000).
+			WithComputeUnitLimit(200_000).
+			WithLoadedAccountsDataSizeLimit(65_536).
+			WithHeapSize(65_536)
+		tx, err := NewTransactionBuilder().
+			AddInstruction(ix1).
+			AddInstruction(ix2).
+			AddInstruction(ix3).
+			SetRecentBlockHash(hashRepeat(0xBB)).
+			SetFeePayer(payer).
+			SetTransactionConfig(cfg).
+			Build()
+		require.NoError(t, err)
+		assert.Equal(t, MessageVersionV1, tx.Message.GetVersion())
+		_, err = tx.Sign(v1TestSigner(t, v1TestPayerKey, v1TestSigner2Key))
+		require.NoError(t, err)
+		got, err := tx.MarshalBinary()
+		require.NoError(t, err)
+		assert.Equal(t, mustHex(t, v1GoldenTxFullConfig), got)
+	})
+
+	t.Run("c_fee_heap", func(t *testing.T) {
+		ix := NewInstruction(p1, AccountMetaSlice{Meta(payer).WRITE().SIGNER()}, []byte{})
+		tx, err := NewTransaction([]Instruction{ix}, hashRepeat(7),
+			TransactionPayer(payer),
+			TransactionV1Config(TransactionConfig{}.WithPriorityFee(1).WithHeapSize(32_768)),
+		)
+		require.NoError(t, err)
+		_, err = tx.Sign(v1TestSigner(t, v1TestPayerKey))
+		require.NoError(t, err)
+		got, err := tx.MarshalBinary()
+		require.NoError(t, err)
+		assert.Equal(t, mustHex(t, v1GoldenTxFeeHeap), got)
+	})
+}
+
+// Port of `v1_transaction_serialization` (test_case 0 = at max size, 1 = over by one).
+func TestV1_TransactionSerializationAtMaxSize(t *testing.T) {
+	const (
+		numSignatures          = 1
+		numAddresses           = 2
+		numInstructionAccounts = 1
+	)
+	overhead := 1 + // version byte
+		numSignatures*64 +
+		fixedHeaderSizeV1 +
+		numAddresses*32 +
+		instructionHeaderSizeV1 +
+		numInstructionAccounts
+
+	for _, delta := range []int{0, 1} {
+		maxDataSize := MaxTransactionSizeV1 - overhead + delta
+		msg := Message{
+			version: MessageVersionV1,
+			Header: MessageHeader{
+				NumRequiredSignatures:       numSignatures,
+				NumReadonlySignedAccounts:   0,
+				NumReadonlyUnsignedAccounts: 0,
+			},
+			AccountKeys:     PublicKeySlice{newUniqueKey(), newUniqueKey()},
+			RecentBlockhash: uniqueHash(),
+			Instructions: []CompiledInstruction{{
+				ProgramIDIndex: 1,
+				Accounts:       []uint16{0},
+				Data:           make([]byte, maxDataSize),
+			}},
+		}
+		tx := &Transaction{Message: msg, Signatures: []Signature{{}}}
+
+		serialized, err := tx.MarshalBinary()
+		require.NoError(t, err)
+		if delta == 0 {
+			assert.Equal(t, MaxTransactionSizeV1, len(serialized), "transaction should be exactly at max size")
+		} else {
+			assert.Equal(t, MaxTransactionSizeV1+delta, len(serialized), "transaction should be over by %d byte(s)", delta)
+		}
+
+		back, err := TransactionFromBytes(serialized)
+		require.NoError(t, err)
+		assert.Equal(t, tx.Signatures, back.Signatures)
+		assert.Equal(t, tx.Message.Header, back.Message.Header)
+		assert.Equal(t, tx.Message.AccountKeys, back.Message.AccountKeys)
+		assert.Equal(t, tx.Message.Instructions, back.Message.Instructions)
+		assert.Equal(t, MessageVersionV1, back.Message.GetVersion())
+	}
+}
+
+// Port of `test_v1_message_in_legacy_transaction`: a V1 message inside a
+// legacy/v0-shaped transaction envelope must be rejected.
+func TestV1_MessageInLegacyTransactionRejected(t *testing.T) {
+	malformed := []byte{
+		0x00, // 0 signatures via compact-u16 -> takes the legacy/v0 path
+		0x81, // V1 message prefix
+		// V1 LegacyHeader (3 bytes)
+		0x01, 0x00, 0x00,
+		// TransactionConfigMask (4 bytes, little-endian)
+		0x00, 0x00, 0x00, 0x00,
+	}
+	malformed = append(malformed, make([]byte, 32)...) // lifetime specifier
+	malformed = append(malformed, 0x00)                // NumInstructions
+	malformed = append(malformed, 0x01)                // NumAddresses
+	malformed = append(malformed, make([]byte, 32)...) // 1 address
+
+	_, err := TransactionFromBytes(malformed)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid message version")
+}
+
+// A legacy body behind a 0x81 prefix must fail to decode.
+func TestV1_LegacyBodyBehindV1PrefixRejected(t *testing.T) {
+	legacy := Message{
+		Header:          MessageHeader{NumRequiredSignatures: 1},
+		AccountKeys:     PublicKeySlice{newUniqueKey(), newUniqueKey()},
+		RecentBlockhash: uniqueHash(),
+		Instructions:    []CompiledInstruction{{ProgramIDIndex: 1, Accounts: []uint16{0}, Data: []byte{1, 2, 3}}},
+	}
+	body, err := legacy.MarshalLegacy()
+	require.NoError(t, err)
+	raw := append([]byte{0x81}, body...)
+	_, err = TransactionFromBytes(raw)
+	require.Error(t, err)
+}
+
+func TestV1_TransactionTruncationNeverPanics(t *testing.T) {
+	raw := mustHex(t, v1GoldenTxFullConfig)
+	for n := 0; n < len(raw); n++ {
+		_, err := TransactionFromBytes(raw[:n])
+		require.Error(t, err, "prefix of %d/%d bytes must fail", n, len(raw))
+	}
+	// One byte fewer than needed for the last signature.
+	_, err := TransactionFromBytes(raw[:len(raw)-1])
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "signatures")
+}
+
+// Any other high-bit first byte is not a valid transaction (upstream parity).
+func TestV1_InvalidTransactionDiscriminator(t *testing.T) {
+	for _, b := range []byte{0x80, 0x82, 0xFF} {
+		_, err := TransactionFromBytes(append([]byte{b}, make([]byte, 200)...))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid transaction discriminator")
+	}
+}
+
+// A decoded header cannot require more signatures than there are keys.
+func TestV1_DecodeRejectsMoreSignaturesThanKeys(t *testing.T) {
+	msg := createTestV1Message(t)
+	msg.Header.NumRequiredSignatures = 5 // 3 keys
+	msgBytes, err := msg.MarshalV1()
+	require.NoError(t, err)
+	_, err = TransactionFromBytes(append(msgBytes, make([]byte, 5*64)...))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only 3 account keys")
+
+	// signerKeys is clamped, so signing a hostile message never panics.
+	tx := &Transaction{Message: msg}
+	_, err = tx.PartialSign(func(PublicKey) *PrivateKey { return nil })
+	require.NoError(t, err)
+	assert.Len(t, tx.Signatures, 3)
+}
+
+// ComputeBudget instructions are no-ops in v1; NewTransaction rejects them.
+func TestV1_NewTransactionRejectsComputeBudgetInstructions(t *testing.T) {
+	payer := newUniqueKey()
+	transfer := NewInstruction(pubkeyRepeat(0x10), AccountMetaSlice{Meta(payer).WRITE().SIGNER()}, []byte{1})
+	cb := NewInstruction(ComputeBudget, AccountMetaSlice{}, []byte{2, 0, 0, 0, 0})
+	_, err := NewTransaction([]Instruction{cb, transfer}, uniqueHash(),
+		TransactionPayer(payer),
+		TransactionV1Config(TransactionConfig{}.WithComputeUnitLimit(1)),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ComputeBudget")
+
+	// Fine as legacy.
+	_, err = NewTransaction([]Instruction{cb, transfer}, uniqueHash(), TransactionPayer(payer))
+	require.NoError(t, err)
+}
+
+func TestV1_TransactionRequiresSignaturesToFitHeader(t *testing.T) {
+	msg := createTestV1Message(t)
+	msg.Header.NumRequiredSignatures = 3
+	msg.Header.NumReadonlyUnsignedAccounts = 0
+	msgBytes, err := msg.MarshalV1()
+	require.NoError(t, err)
+	// Only two signatures follow, header requires three.
+	raw := append(msgBytes, make([]byte, 2*64)...)
+	_, err = TransactionFromBytes(raw)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires 3 signatures")
+}
+
+// Port of transaction/src/sanitized.rs `test_verify_v1_message_data_includes_prefix`
+// (#715): the signed bytes are `0x81 || message body`.
+func TestV1_VerifySignedBytesIncludePrefix(t *testing.T) {
+	payer := v1TestPayerKey.PublicKey()
+	ix := NewInstruction(pubkeyRepeat(0x10), AccountMetaSlice{Meta(payer).WRITE().SIGNER()}, []byte{1})
+	tx, err := NewTransaction([]Instruction{ix}, uniqueHash(),
+		TransactionPayer(payer),
+		TransactionV1Config(TransactionConfig{}.WithComputeUnitLimit(1000)),
+	)
+	require.NoError(t, err)
+	_, err = tx.Sign(v1TestSigner(t, v1TestPayerKey))
+	require.NoError(t, err)
+	require.NoError(t, tx.VerifySignatures())
+
+	msgBytes, err := tx.Message.MarshalBinary()
+	require.NoError(t, err)
+	require.Equal(t, byte(0x81), msgBytes[0])
+	assert.True(t, tx.Signatures[0].Verify(payer, msgBytes))
+	// The signature does NOT verify over the body without the version byte.
+	assert.False(t, tx.Signatures[0].Verify(payer, msgBytes[1:]))
+}
+
+func TestV1_NewTransactionRejectsAddressTables(t *testing.T) {
+	payer := newUniqueKey()
+	table := newUniqueKey()
+	extra := newUniqueKey()
+	ix := NewInstruction(pubkeyRepeat(0x10), AccountMetaSlice{Meta(payer).WRITE().SIGNER(), Meta(extra).WRITE()}, []byte{1})
+
+	_, err := NewTransaction([]Instruction{ix}, uniqueHash(),
+		TransactionPayer(payer),
+		TransactionAddressTables(map[PublicKey]PublicKeySlice{table: {extra}}),
+		TransactionMessageVersion(MessageVersionV1),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "address lookup tables")
+
+	_, err = NewTransaction([]Instruction{ix}, uniqueHash(),
+		TransactionPayer(payer),
+		TransactionMessageVersion(MessageVersion(42)),
+	)
+	require.Error(t, err)
+}
+
+func TestV1_NewTransactionVersionOption(t *testing.T) {
+	payer := newUniqueKey()
+	ix := NewInstruction(pubkeyRepeat(0x10), AccountMetaSlice{Meta(payer).WRITE().SIGNER()}, []byte{1})
+	bh := uniqueHash()
+
+	// Explicit v0 without address tables is honored.
+	tx, err := NewTransaction([]Instruction{ix}, bh, TransactionPayer(payer), TransactionMessageVersion(MessageVersionV0))
+	require.NoError(t, err)
+	assert.Equal(t, MessageVersionV0, tx.Message.GetVersion())
+	raw, err := tx.MarshalBinary()
+	require.NoError(t, err)
+	assert.Equal(t, byte(0x80), raw[1+64]) // after compact-u16 len + 1 padded signature
+
+	// Default is legacy.
+	tx, err = NewTransaction([]Instruction{ix}, bh, TransactionPayer(payer))
+	require.NoError(t, err)
+	assert.Equal(t, MessageVersionLegacy, tx.Message.GetVersion())
+
+	// Config with a non-V1 version is an error, regardless of option order.
+	_, err = NewTransaction([]Instruction{ix}, bh, TransactionPayer(payer),
+		TransactionV1Config(TransactionConfig{}.WithComputeUnitLimit(1)),
+		TransactionMessageVersion(MessageVersionLegacy),
+	)
+	require.Error(t, err)
+	_, err = NewTransaction([]Instruction{ix}, bh, TransactionPayer(payer),
+		TransactionMessageVersion(MessageVersionV0),
+		TransactionV1Config(TransactionConfig{}),
+	)
+	require.NoError(t, err, "empty config after V0: last version option wins")
+
+	// Builder helpers.
+	tx, err = NewTransactionBuilder().AddInstruction(ix).SetRecentBlockHash(bh).SetFeePayer(payer).SetVersion(MessageVersionV1).Build()
+	require.NoError(t, err)
+	assert.Equal(t, MessageVersionV1, tx.Message.GetVersion())
+	assert.True(t, tx.Message.TransactionConfig.IsEmpty())
+}
+
+// Malformed-but-well-formed-on-the-wire messages decode and are caught by Sanitize.
+func TestV1_DecodedMessageFailsSanitize(t *testing.T) {
+	msg := createTestV1Message(t)
+	base := mustMarshalV1(t, &msg)
+	// 0x81 | hdr(3) | mask(4) | lifetime(32) | counts(2) | 3 addrs | cu(4) | ix hdr(4) | payload
+	ixHeaderOff := 1 + 3 + 4 + 32 + 1 + 1 + 3*32 + 4
+	payloadOff := ixHeaderOff + 4
+
+	// program_id_index out of range
+	data := append([]byte(nil), base...)
+	data[ixHeaderOff] = 7
+	decoded := mustUnmarshalV1(t, data)
+	assert.Equal(t, uint16(7), decoded.Instructions[0].ProgramIDIndex)
+	require.Error(t, decoded.Sanitize())
+
+	// account index out of range
+	data = append([]byte(nil), base...)
+	data[payloadOff] = 9
+	decoded = mustUnmarshalV1(t, data)
+	assert.Equal(t, uint16(9), decoded.Instructions[0].Accounts[0])
+	require.Error(t, decoded.Sanitize())
+
+	// duplicate address (copy addr[0] over addr[1])
+	data = append([]byte(nil), base...)
+	addrOff := 1 + 3 + 4 + 32 + 1 + 1
+	copy(data[addrOff+32:addrOff+64], data[addrOff:addrOff+32])
+	decoded = mustUnmarshalV1(t, data)
+	require.Error(t, decoded.Sanitize())
+
+	// heap size present but out of bounds: set bit 4 and append the value
+	data = append([]byte(nil), base[:ixHeaderOff]...)
+	data[4] |= byte(TransactionConfigMaskHeapSize)
+	data = append(data, 0, 4, 0, 0) // heap = 1024 (< 32 KiB)
+	data = append(data, base[ixHeaderOff:]...)
+	decoded = mustUnmarshalV1(t, data)
+	require.NotNil(t, decoded.TransactionConfig.HeapSize)
+	assert.Equal(t, uint32(1024), *decoded.TransactionConfig.HeapSize)
+	require.Error(t, decoded.Sanitize())
+}
+
+func TestV1_NewTransactionSameLayoutAsLegacy(t *testing.T) {
+	payer := newUniqueKey()
+	a := newUniqueKey()
+	b := newUniqueKey()
+	prog := newUniqueKey()
+	ix := NewInstruction(prog, AccountMetaSlice{Meta(payer).WRITE().SIGNER(), Meta(a).WRITE(), Meta(b)}, []byte{9, 8, 7})
+	bh := uniqueHash()
+
+	legacyTx, err := NewTransaction([]Instruction{ix}, bh, TransactionPayer(payer))
+	require.NoError(t, err)
+	v1Tx, err := NewTransaction([]Instruction{ix}, bh, TransactionPayer(payer), TransactionV1Config(TransactionConfig{}.WithComputeUnitLimit(50_000)))
+	require.NoError(t, err)
+
+	assert.Equal(t, MessageVersionLegacy, legacyTx.Message.GetVersion())
+	assert.Equal(t, MessageVersionV1, v1Tx.Message.GetVersion())
+	assert.Equal(t, legacyTx.Message.Header, v1Tx.Message.Header)
+	assert.Equal(t, legacyTx.Message.AccountKeys, v1Tx.Message.AccountKeys)
+	assert.Equal(t, legacyTx.Message.Instructions, v1Tx.Message.Instructions)
+	assert.Equal(t, uint32(50_000), *v1Tx.Message.TransactionConfig.ComputeUnitLimit)
+	require.NoError(t, v1Tx.Message.Sanitize())
+
+	// V1 with too many accounts fails early in NewTransaction.
+	metas := AccountMetaSlice{Meta(payer).WRITE().SIGNER()}
+	for range 64 {
+		metas = append(metas, Meta(newUniqueKey()))
+	}
+	big := NewInstruction(prog, metas, nil)
+	_, err = NewTransaction([]Instruction{big}, bh, TransactionPayer(payer), TransactionMessageVersion(MessageVersionV1))
+	require.Error(t, err)
+	assert.True(t, IsSanitizeError(err))
+	// ...but is fine as legacy.
+	_, err = NewTransaction([]Instruction{big}, bh, TransactionPayer(payer))
+	require.NoError(t, err)
+}
+
+func TestV1_MarshalBinaryPadsMissingAndRejectsExtraSignatures(t *testing.T) {
+	msg := createTestV1Message(t)
+	tx := &Transaction{Message: msg}
+
+	// No signatures: padded with one zero signature.
+	raw, err := tx.MarshalBinary()
+	require.NoError(t, err)
+	msgBytes := mustMarshalV1(t, &msg)
+	assert.Equal(t, len(msgBytes)+64, len(raw))
+	assert.Equal(t, make([]byte, 64), raw[len(msgBytes):])
+
+	// Too many signatures: error (no length prefix on the wire).
+	tx.Signatures = []Signature{{}, {}}
+	_, err = tx.MarshalBinary()
+	require.Error(t, err)
+}
+
+func TestV1_TransactionSanitize(t *testing.T) {
+	msg := createTestV1Message(t)
+	tx := &Transaction{Message: msg, Signatures: []Signature{{}}}
+	require.NoError(t, tx.Sanitize())
+
+	tx.Signatures = nil
+	err := tx.Sanitize()
+	require.Error(t, err)
+	assert.True(t, IsSanitizeError(err))
+
+	tx.Signatures = []Signature{{}}
+	tx.Message.TransactionConfig = tx.Message.TransactionConfig.WithHeapSize(MaxHeapSizeV1 + 1024)
+	err = tx.Sanitize()
+	require.Error(t, err)
+	assert.True(t, IsSanitizeError(err))
+}
+
+func TestV1_TransactionJSONRoundtrip(t *testing.T) {
+	tx, err := TransactionFromBytes(mustHex(t, v1GoldenTxFullConfig))
+	require.NoError(t, err)
+
+	data, err := json.Marshal(tx)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"transactionConfig":{"priorityFee":5000,"computeUnitLimit":200000,"loadedAccountsDataSizeLimit":65536,"heapSize":65536}`)
+
+	var back Transaction
+	require.NoError(t, json.Unmarshal(data, &back))
+	assert.Equal(t, MessageVersionV1, back.Message.GetVersion())
+	assert.Equal(t, tx.Signatures, back.Signatures)
+	assert.Equal(t, tx.Message.Header, back.Message.Header)
+	assert.Equal(t, tx.Message.AccountKeys, back.Message.AccountKeys)
+	assert.Equal(t, tx.Message.Instructions, back.Message.Instructions)
+	assert.Equal(t, tx.Message.TransactionConfig, back.Message.TransactionConfig)
+
+	// The JSON-decoded transaction re-encodes to the original wire bytes.
+	again, err := back.MarshalBinary()
+	require.NoError(t, err)
+	assert.Equal(t, mustHex(t, v1GoldenTxFullConfig), again)
+}
+
+func TestV1_UsesDurableNonceUnaffected(t *testing.T) {
+	tx, err := TransactionFromBytes(mustHex(t, v1GoldenTxEmptyConfig))
+	require.NoError(t, err)
+	assert.False(t, tx.UsesDurableNonce())
+	assert.Equal(t, 1, tx.NumSigners())
+	assert.Equal(t, 2, tx.NumReadonlyAccounts())
+	assert.Equal(t, 2, tx.NumWriteableAccounts()) // payer + [0x02;32]
+}
+
+func TestV1_DecoderIsGenericPath(t *testing.T) {
+	// TransactionFromDecoder / bin.Decoder.Decode also work for V1.
+	raw := mustHex(t, v1GoldenTxFeeHeap)
+	tx, err := TransactionFromDecoder(bin.NewBinDecoder(raw))
+	require.NoError(t, err)
+	assert.Equal(t, MessageVersionV1, tx.Message.GetVersion())
+	assert.Equal(t, uint64(1), *tx.Message.TransactionConfig.PriorityFee)
+	assert.Equal(t, uint32(32_768), *tx.Message.TransactionConfig.HeapSize)
+}

--- a/transaction_v1_test.go
+++ b/transaction_v1_test.go
@@ -2,6 +2,7 @@ package solana
 
 import (
 	"crypto/ed25519"
+	"encoding/base64"
 	"encoding/hex"
 	"testing"
 
@@ -379,6 +380,42 @@ func TestV1_InvalidTransactionDiscriminator(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid transaction discriminator")
 	}
+}
+
+// SIMD-0385: no trailing data after the signatures. Slice-level decoding is
+// strict for v1; the streaming decoder stays lenient (wincode parity), and
+// legacy/v0 slices keep their historical lenient behavior.
+func TestV1_TrailingBytesRejected(t *testing.T) {
+	raw := mustHex(t, v1GoldenTxFeeHeap)
+	padded := append(append([]byte{}, raw...), 0x00)
+
+	_, err := TransactionFromBytes(padded)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "trailing bytes")
+	_, err = TransactionFromBase64(base64.StdEncoding.EncodeToString(padded))
+	require.Error(t, err)
+
+	// Exact bytes still decode.
+	_, err = TransactionFromBytes(raw)
+	require.NoError(t, err)
+
+	// Streaming decode is lenient and leaves the extra byte unread.
+	decoder := bin.NewBinDecoder(padded)
+	tx, err := TransactionFromDecoder(decoder)
+	require.NoError(t, err)
+	assert.Equal(t, MessageVersionV1, tx.Message.GetVersion())
+	assert.Equal(t, 1, decoder.Remaining())
+
+	// Legacy transactions with trailing bytes remain accepted.
+	legacyTx, err := NewTransaction(
+		[]Instruction{NewInstruction(pubkeyRepeat(0x10), AccountMetaSlice{Meta(newUniqueKey()).WRITE().SIGNER()}, []byte{1})},
+		uniqueHash(),
+	)
+	require.NoError(t, err)
+	legacyRaw, err := legacyTx.MarshalBinary()
+	require.NoError(t, err)
+	_, err = TransactionFromBytes(append(legacyRaw, 0x00))
+	require.NoError(t, err)
 }
 
 // A decoded header cannot require more signatures than there are keys.


### PR DESCRIPTION
### Problem

solana-go could not build, sign, decode or validate V1 (SIMD-0385) transactions

### Summary of Changes

- Messages can now be V1: they carry an optional inline compute budget (priority fee, compute unit limit, loaded-account data limit, heap size) and are encoded/decoded in the V1 wire layout, with the version byte included in the signed bytes and malformed budget flags rejected on decode.
- Transactions detect the format from the first byte, write and read a fixed number of signatures after the message for V1, and reject mixed envelopes and headers that require more signatures than there are keys.
- Validation enforces the V1 rules: at most 12 signatures, 64 addresses and 64 instructions, heap size a multiple of 1 KiB within 32-256 KiB, no duplicate addresses and no lookup tables; legacy, v0 and V1 share the common header/instruction checks.
- Transaction building lets callers pick the version and set the inline budget; V1 rejects address lookup tables and compute-budget instructions (no-ops in V1) and fails early on the structural limits.
- A V1 message can no longer be silently downgraded in a way that drops its budget, decoders reset stale state when reused, and signing a message with a hostile header no longer panics.
- JSON follows the RPC shape for V1 (budget object present, no lookups) and errors when both are present; parsed RPC messages expose the budget.
- Ported upstream tests plus Rust-generated golden vectors, README section, examples and a runnable doc example; public API changes are additive.

cc @welkinbai