### PR TITLE
feat: make slot time dependent on feature sets

### DIFF
--- a/feature_gate.go
+++ b/feature_gate.go
@@ -1,0 +1,116 @@
+// Copyright 2026 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package solana
+
+// Ported from solana-sdk feature-gate-interface (state.rs).
+
+import (
+	"fmt"
+
+	bin "github.com/gagliardetto/binary"
+)
+
+// SIMD-0525 slot-time reduction feature gates, in activation order.
+// Each takes effect one epoch after its activation epoch (see sysvar.MsPerSlotAt).
+var (
+	FeatureReduceSlotTimeTo350ms = MustPublicKeyFromBase58("iBRL5RuWhw4yqaAZu96RUULHckHTZAoe2b77qaV38JZ")
+	FeatureReduceSlotTimeTo300ms = MustPublicKeyFromBase58("iBRLL3k18HST852F1Mf3Lv83waTNQmmqvKDxvYGwQFL")
+	FeatureReduceSlotTimeTo250ms = MustPublicKeyFromBase58("iBRLMc81UjRa8fn8A6eE8bJTnRbgQoPTynM51akENCV")
+	FeatureReduceSlotTimeTo200ms = MustPublicKeyFromBase58("iBRLjhJnkmDZgNoZRDMW11d8ZV7HvsL3vAyRjZB5npW")
+)
+
+// FeatureSizeOf is the serialized size of a Feature account (1-byte option tag + u64).
+const FeatureSizeOf = 9
+
+// Feature is the state of a feature-gate account (owner FeatureProgramID).
+type Feature struct {
+	// Slot at which the feature was activated; nil while pending.
+	ActivatedAt *uint64
+}
+
+// IsActive reports whether the feature has been activated.
+func (f Feature) IsActive() bool {
+	return f.ActivatedAt != nil
+}
+
+func (f Feature) MarshalWithEncoder(encoder *bin.Encoder) error {
+	if f.ActivatedAt == nil {
+		return encoder.WriteByte(0)
+	}
+	if err := encoder.WriteByte(1); err != nil {
+		return err
+	}
+	return encoder.WriteUint64(*f.ActivatedAt, bin.LE)
+}
+
+func (f *Feature) UnmarshalWithDecoder(decoder *bin.Decoder) error {
+	// Bincode Option<u64>: strict 0/1 tag, lenient about trailing bytes.
+	tag, err := decoder.ReadByte()
+	if err != nil {
+		return fmt.Errorf("unable to read feature option tag: %w", err)
+	}
+	switch tag {
+	case 0:
+		f.ActivatedAt = nil
+		return nil
+	case 1:
+		v, err := decoder.ReadUint64(bin.LE)
+		if err != nil {
+			return fmt.Errorf("unable to read feature activation slot: %w", err)
+		}
+		f.ActivatedAt = &v
+		return nil
+	default:
+		return fmt.Errorf("invalid feature option tag: %d", tag)
+	}
+}
+
+// DecodeFeature decodes a bincode-encoded Feature (Option<u64>).
+func DecodeFeature(data []byte) (Feature, error) {
+	var f Feature
+	err := f.UnmarshalWithDecoder(bin.NewBinDecoder(data))
+	return f, err
+}
+
+// FeatureFromAccount decodes a Feature after checking the account owner,
+// mirroring feature-gate-interface from_account.
+func FeatureFromAccount(owner PublicKey, data []byte) (Feature, error) {
+	if !owner.Equals(FeatureProgramID) {
+		return Feature{}, fmt.Errorf("invalid feature account owner: %s", owner)
+	}
+	// Upstream from_account enforces the minimum account size even for
+	// pending features, beyond what the lenient bincode decode requires.
+	if len(data) < FeatureSizeOf {
+		return Feature{}, fmt.Errorf("feature account data too short: %d bytes, need %d", len(data), FeatureSizeOf)
+	}
+	return DecodeFeature(data)
+}
+
+// FeatureSet maps feature gate IDs to their activation slot,
+// a minimal counterpart of the Rust FeatureSet's active map.
+// The zero value (nil) is a valid, empty set.
+type FeatureSet map[PublicKey]uint64
+
+// ActivatedSlot returns the activation slot of the feature, if activated.
+func (fs FeatureSet) ActivatedSlot(id PublicKey) (uint64, bool) {
+	slot, ok := fs[id]
+	return slot, ok
+}
+
+// IsActive reports whether the feature is activated.
+func (fs FeatureSet) IsActive(id PublicKey) bool {
+	_, ok := fs[id]
+	return ok
+}

--- a/feature_gate_test.go
+++ b/feature_gate_test.go
@@ -1,0 +1,82 @@
+package solana
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	bin "github.com/gagliardetto/binary"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Real mainnet-beta account data of FeatureReduceSlotTimeTo350ms
+// (iBRL5RuWhw4yqaAZu96RUULHckHTZAoe2b77qaV38JZ), activated at slot 440208000.
+const mainnet350msFeatureHex = "01800a3d1a00000000"
+
+func TestDecodeFeature_ActivatedMainnetVector(t *testing.T) {
+	data, err := hex.DecodeString(mainnet350msFeatureHex)
+	require.NoError(t, err)
+
+	f, err := FeatureFromAccount(FeatureProgramID, data)
+	require.NoError(t, err)
+	require.True(t, f.IsActive())
+	assert.Equal(t, uint64(440208000), *f.ActivatedAt)
+
+	// Encode round-trip is byte-identical.
+	var buf bytes.Buffer
+	require.NoError(t, f.MarshalWithEncoder(bin.NewBinEncoder(&buf)))
+	assert.Equal(t, data, buf.Bytes())
+}
+
+func TestDecodeFeature_Pending(t *testing.T) {
+	f, err := DecodeFeature([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0})
+	require.NoError(t, err)
+	assert.False(t, f.IsActive())
+	assert.Nil(t, f.ActivatedAt)
+
+	var buf bytes.Buffer
+	require.NoError(t, f.MarshalWithEncoder(bin.NewBinEncoder(&buf)))
+	assert.Equal(t, []byte{0}, buf.Bytes())
+}
+
+func TestDecodeFeature_Invalid(t *testing.T) {
+	_, err := DecodeFeature(nil)
+	require.Error(t, err)
+
+	_, err = DecodeFeature([]byte{1, 2, 3}) // tag=1 but truncated value
+	require.Error(t, err)
+
+	_, err = DecodeFeature([]byte{2, 0, 0, 0, 0, 0, 0, 0, 0}) // invalid option tag
+	require.Error(t, err)
+
+	// Trailing bytes are tolerated (bincode parity).
+	f, err := DecodeFeature([]byte{1, 5, 0, 0, 0, 0, 0, 0, 0, 0xFF})
+	require.NoError(t, err)
+	assert.Equal(t, uint64(5), *f.ActivatedAt)
+
+	// Wrong owner.
+	_, err = FeatureFromAccount(TokenProgramID, []byte{0, 0, 0, 0, 0, 0, 0, 0, 0})
+	require.Error(t, err)
+
+	// Owner check also enforces the minimum size (upstream from_account),
+	// unlike lenient DecodeFeature which accepts a bare pending tag.
+	_, err = FeatureFromAccount(FeatureProgramID, []byte{0})
+	require.Error(t, err)
+	_, err = DecodeFeature([]byte{0})
+	require.NoError(t, err)
+}
+
+func TestFeatureSet(t *testing.T) {
+	var nilSet FeatureSet
+	assert.False(t, nilSet.IsActive(FeatureReduceSlotTimeTo350ms))
+	_, ok := nilSet.ActivatedSlot(FeatureReduceSlotTimeTo350ms)
+	assert.False(t, ok)
+
+	fs := FeatureSet{FeatureReduceSlotTimeTo350ms: 440208000}
+	assert.True(t, fs.IsActive(FeatureReduceSlotTimeTo350ms))
+	slot, ok := fs.ActivatedSlot(FeatureReduceSlotTimeTo350ms)
+	require.True(t, ok)
+	assert.Equal(t, uint64(440208000), slot)
+	assert.False(t, fs.IsActive(FeatureReduceSlotTimeTo300ms))
+}

--- a/sysvar/clock.go
+++ b/sysvar/clock.go
@@ -30,9 +30,12 @@ const (
 	DefaultHashesPerSecond uint64 = 10_000_000
 	SecondsPerDay          uint64 = 24 * 60 * 60
 	TicksPerDay            uint64 = DefaultTicksPerSecond * SecondsPerDay
-	// DefaultSlotsPerEpoch is ~2 days of slots (432000).
+	// DefaultSlotsPerEpoch is 432000 slots (~2 days at the default 400ms
+	// slot time; less as SIMD-0525 reductions activate).
 	DefaultSlotsPerEpoch uint64 = 2 * TicksPerDay / DefaultTicksPerSlot
-	// DefaultMsPerSlot is the default slot duration in milliseconds (400).
+	// DefaultMsPerSlot is the default/target slot duration in milliseconds (400).
+	// SIMD-0525 feature gates can reduce the actual duration (e.g. 350ms on
+	// mainnet-beta starting at epoch 1020); use MsPerSlotAt for the effective value.
 	DefaultMsPerSlot uint64 = 1000 * DefaultTicksPerSlot / DefaultTicksPerSecond
 	// MaxRecentBlockhashes is the number of blockhashes kept in the
 	// RecentBlockhashes sysvar (300).

--- a/sysvar/slot_time.go
+++ b/sysvar/slot_time.go
@@ -1,0 +1,85 @@
+// Copyright 2026 github.com/gagliardetto
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sysvar
+
+// SIMD-0525 slot-time reduction; ported from agave runtime/src/slot_params.rs.
+// Assumes the default 400ms genesis slot time (true for mainnet-beta, testnet
+// and devnet); clusters with a custom genesis baseline are not modeled.
+
+import (
+	"github.com/gagliardetto/solana-go"
+)
+
+// Slot durations selectable by the SIMD-0525 feature gates
+// (the baseline is DefaultMsPerSlot).
+const (
+	MsPerSlot350 uint64 = 350
+	MsPerSlot300 uint64 = 300
+	MsPerSlot250 uint64 = 250
+	MsPerSlot200 uint64 = 200
+)
+
+// SlotTimeGate pairs a slot-time reduction feature gate with its slot duration.
+type SlotTimeGate struct {
+	FeatureID solana.PublicKey
+	MsPerSlot uint64
+}
+
+var slotTimeGates = [4]SlotTimeGate{
+	{solana.FeatureReduceSlotTimeTo350ms, MsPerSlot350},
+	{solana.FeatureReduceSlotTimeTo300ms, MsPerSlot300},
+	{solana.FeatureReduceSlotTimeTo250ms, MsPerSlot250},
+	{solana.FeatureReduceSlotTimeTo200ms, MsPerSlot200},
+}
+
+// SlotTimeGates returns the reduction gates in intended activation order.
+func SlotTimeGates() []SlotTimeGate {
+	gates := slotTimeGates
+	return gates[:]
+}
+
+// MsPerSlotAt returns the slot duration in effect at slot, given the set of
+// activated features (fetch the gate accounts and decode them with
+// solana.FeatureFromAccount; a nil set means no reductions).
+//
+// A gate activated in epoch E takes effect at the first slot of epoch E+1.
+// The result is the minimum duration among effective gates, so it never
+// increases as slots advance regardless of activation order (agave parity).
+func MsPerSlotAt(slot uint64, es EpochSchedule, features solana.FeatureSet) uint64 {
+	if es.SlotsPerEpoch == 0 {
+		// Not a valid schedule (e.g. a zero value): claim no reduction
+		// rather than treating every gate as effective at slot 0.
+		return DefaultMsPerSlot
+	}
+	ms := DefaultMsPerSlot
+	for _, gate := range slotTimeGates {
+		activationSlot, ok := features.ActivatedSlot(gate.FeatureID)
+		if !ok {
+			continue
+		}
+		effectiveSlot := es.GetFirstSlotInEpoch(satAddU64(es.GetEpoch(activationSlot), 1))
+		if effectiveSlot <= slot && gate.MsPerSlot < ms {
+			ms = gate.MsPerSlot
+		}
+	}
+	return ms
+}
+
+// MsPerSlotInEpoch returns the slot duration in effect during epoch.
+// Gates only take effect at epoch boundaries, so the duration is constant
+// within an epoch.
+func MsPerSlotInEpoch(epoch uint64, es EpochSchedule, features solana.FeatureSet) uint64 {
+	return MsPerSlotAt(es.GetFirstSlotInEpoch(epoch), es, features)
+}

--- a/sysvar/slot_time_test.go
+++ b/sysvar/slot_time_test.go
@@ -1,0 +1,93 @@
+package sysvar
+
+import (
+	"testing"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/assert"
+)
+
+// Mainnet-beta scenario: reduce_slot_time_to_350ms activated at slot
+// 440208000 (first slot of epoch 1019) -> effective at epoch 1020.
+func TestMsPerSlotAt_Mainnet350ms(t *testing.T) {
+	// Mainnet-beta runs without warmup epochs (epoch = slot / 432000).
+	es := NewEpochScheduleCustom(DefaultSlotsPerEpoch, DefaultSlotsPerEpoch, false)
+	features := solana.FeatureSet{
+		solana.FeatureReduceSlotTimeTo350ms: 440208000,
+	}
+
+	epoch1020Start := es.GetFirstSlotInEpoch(1020)
+	assert.Equal(t, uint64(440640000), epoch1020Start)
+
+	assert.Equal(t, DefaultMsPerSlot, MsPerSlotAt(440208000, es, features)) // activation slot: still 400
+	assert.Equal(t, DefaultMsPerSlot, MsPerSlotAt(440464041, es, features)) // mid epoch 1019
+	assert.Equal(t, DefaultMsPerSlot, MsPerSlotAt(epoch1020Start-1, es, features))
+	assert.Equal(t, MsPerSlot350, MsPerSlotAt(epoch1020Start, es, features)) // effective
+	assert.Equal(t, MsPerSlot350, MsPerSlotAt(epoch1020Start+1_000_000, es, features))
+
+	assert.Equal(t, DefaultMsPerSlot, MsPerSlotInEpoch(1019, es, features))
+	assert.Equal(t, MsPerSlot350, MsPerSlotInEpoch(1020, es, features))
+	assert.Equal(t, MsPerSlot350, MsPerSlotInEpoch(1021, es, features))
+}
+
+func TestMsPerSlotAt_NoGates(t *testing.T) {
+	es := NewEpochSchedule(DefaultSlotsPerEpoch)
+	assert.Equal(t, DefaultMsPerSlot, MsPerSlotAt(0, es, nil))
+	assert.Equal(t, DefaultMsPerSlot, MsPerSlotAt(1<<40, es, nil))
+	assert.Equal(t, DefaultMsPerSlot, MsPerSlotInEpoch(100, es, nil))
+}
+
+// Out-of-order activations must never increase the slot duration (agave parity).
+func TestMsPerSlotAt_OutOfOrderNeverIncreases(t *testing.T) {
+	es := NewEpochSchedule(DefaultSlotsPerEpoch)
+	// 300ms activates in epoch 10, 350ms later in epoch 20.
+	features := solana.FeatureSet{
+		solana.FeatureReduceSlotTimeTo300ms: es.GetFirstSlotInEpoch(10),
+		solana.FeatureReduceSlotTimeTo350ms: es.GetFirstSlotInEpoch(20),
+	}
+
+	assert.Equal(t, DefaultMsPerSlot, MsPerSlotInEpoch(10, es, features))
+	assert.Equal(t, MsPerSlot300, MsPerSlotInEpoch(11, es, features))
+	// The later, longer gate must not bump it back up to 350.
+	assert.Equal(t, MsPerSlot300, MsPerSlotInEpoch(21, es, features))
+
+	prev := DefaultMsPerSlot
+	for epoch := uint64(0); epoch < 30; epoch++ {
+		ms := MsPerSlotInEpoch(epoch, es, features)
+		assert.LessOrEqual(t, ms, prev, "epoch %d", epoch)
+		prev = ms
+	}
+}
+
+// Degenerate inputs must fail safe (no reduction claimed).
+func TestMsPerSlotAt_DegenerateInputs(t *testing.T) {
+	features := solana.FeatureSet{
+		solana.FeatureReduceSlotTimeTo200ms: 1,
+	}
+
+	// Zero-value schedule: gates must not be reported effective from slot 0.
+	assert.Equal(t, DefaultMsPerSlot, MsPerSlotAt(1<<40, EpochSchedule{}, features))
+
+	// Activation epoch near the maximum: the epoch+1 hop saturates instead
+	// of wrapping to epoch 0 (which would make the gate always effective).
+	es := NewEpochSchedule(DefaultSlotsPerEpoch)
+	huge := solana.FeatureSet{
+		solana.FeatureReduceSlotTimeTo200ms: ^uint64(0),
+	}
+	assert.Equal(t, DefaultMsPerSlot, MsPerSlotAt(0, es, huge))
+	assert.Equal(t, DefaultMsPerSlot, MsPerSlotAt(1<<40, es, huge))
+}
+
+func TestSlotTimeGates_Order(t *testing.T) {
+	gates := SlotTimeGates()
+	assert.Len(t, gates, 4)
+	assert.Equal(t, MsPerSlot350, gates[0].MsPerSlot)
+	assert.Equal(t, MsPerSlot200, gates[3].MsPerSlot)
+	for i := 1; i < len(gates); i++ {
+		assert.Less(t, gates[i].MsPerSlot, gates[i-1].MsPerSlot)
+	}
+
+	// The returned slice is a copy; callers cannot corrupt the gate table.
+	gates[0].MsPerSlot = 1
+	assert.Equal(t, MsPerSlot350, SlotTimeGates()[0].MsPerSlot)
+}


### PR DESCRIPTION
### Problem

Solana's slot time is no longer a fixed 400 ms: SIMD-0525 feature gates reduce it in steps (350 ms is activated on mainnet-beta, effective at epoch 1020), and the SDK had no way to decode feature-gate accounts or determine the slot duration actually in effect

### Summary of Changes

- feature-gate account state can now be decoded and re-encoded (activation slot or pending), including an owner-checked variant that mirrors the Rust SDK's stricter account validation
- feature-set abstraction maps activated gates to their activation slots; an empty or absent set safely means "no reductions"
- new helpers answer "what is the slot duration at this slot / in this epoch": a gate activated in epoch E takes effect at the first slot of epoch E+1, and the duration never increases as slots advance, even with out-of-order activations (matching the validator's behavior)
- known slot-time reduction gates (350/300/250/200 ms) and their addresses are published in activation order.
Hardened against bad input: degenerate epoch schedules and extreme activation slots fail safe to the 400 ms default instead of reporting a reduction everywhere
- default 400 ms constant is unchanged (upstream parity) but its docs now explain it is a target that gates can reduce; tests pin the real mainnet activation data and boundary behavior