### PR TITLE
fix(zkencryption)!: align key derivation with solana-conf-bal/v1

### DIFF
--- a/programs/token-2022/zkencryption/ae_key.go
+++ b/programs/token-2022/zkencryption/ae_key.go
@@ -1,7 +1,8 @@
 package zkencryption
 
 import (
-	"crypto/sha3"
+	"crypto/hkdf"
+	"crypto/sha512"
 	"fmt"
 
 	"github.com/gagliardetto/solana-go"
@@ -11,70 +12,76 @@ import (
 // AeKeyLen is the byte length of an authenticated-encryption key (AES-128-GCM-SIV).
 const AeKeyLen = 16
 
-// aeSigningDomain is the domain-separation prefix prepended to the public
-// seed before signing. It must match b"AeKey" in solana-zk-sdk.
-const aeSigningDomain = "AeKey"
+// aeInfo is the HKDF info string that scopes the AE key expansion, matching
+// AE_HKDF_INFO in solana-zk-sdk.
+const aeInfo = "ae"
 
-// minAeSeedLen / maxAeSeedLen mirror the bounds enforced in solana-zk-sdk's
-// SeedDerivable::from_seed implementation for AeKey.
-const (
-	minAeSeedLen = AeKeyLen
-	maxAeSeedLen = 65535
-)
+// aeMinSeedLen is the minimum seed length accepted by the AE derivation. It
+// mirrors MINIMUM_SEED_LEN in solana-zk-sdk's derive_confidential_keys_from_ikm
+// (AE_KEY_LEN = 16), which is independent from the ElGamal minimum of 32.
+const aeMinSeedLen = AeKeyLen
 
 // AeKey is a 128-bit authenticated-encryption key used by the Token-2022
 // confidential-transfer extension to encrypt u64 amounts under AES-128-GCM-SIV.
 type AeKey [AeKeyLen]byte
 
-// AeKeyFromSeed derives an AeKey from an entropy seed by hashing the seed with
-// SHA3-512 and taking the first 16 bytes, matching SeedDerivable::from_seed in
-// solana-zk-sdk.
-func AeKeyFromSeed(seed []byte) (AeKey, error) {
-	if len(seed) < minAeSeedLen {
+// deriveAeKey implements the solana-conf-bal/v1 derivation:
+// HKDF-SHA512(salt=SigningDomain, ikm).expand(info="ae", 16), matching
+// derive_confidential_keys_from_ikm in solana-zk-sdk.
+func deriveAeKey(ikm []byte) (AeKey, error) {
+	if len(ikm) < aeMinSeedLen {
 		return AeKey{}, ErrSeedTooShort
 	}
-	if len(seed) > maxAeSeedLen {
+	if len(ikm) > maxSeedLen {
 		return AeKey{}, ErrSeedTooLong
 	}
-	h := sha3.Sum512(seed)
+
+	key, err := hkdf.Key(sha512.New, ikm, []byte(SigningDomain), aeInfo, AeKeyLen)
+	if err != nil {
+		return AeKey{}, fmt.Errorf("zkencryption: HKDF expand ae: %w", err)
+	}
+
 	var out AeKey
-	copy(out[:], h[:AeKeyLen])
+	copy(out[:], key)
+	// key holds expanded secret material; scrub it before it leaves scope.
+	clear(key)
 	return out, nil
 }
 
-// AeKeyFromSignature derives an AeKey from an ed25519 signature by using
-// SHA3-512(signature) as the seed. Mirrors AeKey::seed_from_signature +
-// from_seed in solana-zk-sdk. No default-signature check is performed here;
-// use AeKeyFromSigner if the signature originates from a local signer.
+// AeKeyFromSeed derives an AeKey from raw input key material, matching
+// derive_confidential_keys_from_ikm in solana-zk-sdk.
+func AeKeyFromSeed(seed []byte) (AeKey, error) {
+	return deriveAeKey(seed)
+}
+
+// AeKeyFromSignature derives an AeKey from an ed25519 signature over
+// ConfidentialDerivationMessage. Mirrors derive_confidential_keys_from_signature
+// in solana-zk-sdk. An all-zero (default) signature is rejected, matching the
+// Rust implementation.
 func AeKeyFromSignature(sig solana.Signature) (AeKey, error) {
-	h := sha3.Sum512(sig[:])
-	return AeKeyFromSeed(h[:])
+	if sig == (solana.Signature{}) {
+		return AeKey{}, ErrDefaultSignature
+	}
+	return deriveAeKey(sig[:])
 }
 
 // AeKeyFromSigner deterministically derives an AeKey from a Solana signer and
-// a public seed. The signer signs b"AeKey" || publicSeed; the signature is
-// then hashed with SHA3-512 and the result fed into AeKeyFromSeed. An
-// all-zero (default) signature is rejected, matching the Rust implementation.
+// a public seed. The signer signs b"solana-conf-bal/v1" || publicSeed (see
+// ConfidentialDerivationMessage); the signature is fed through the HKDF-SHA512
+// solana-conf-bal/v1 derivation. The all-zero signature rejection lives in
+// AeKeyFromSignature.
 func AeKeyFromSigner(signer Signer, publicSeed []byte) (AeKey, error) {
-	msg := make([]byte, 0, len(aeSigningDomain)+len(publicSeed))
-	msg = append(msg, aeSigningDomain...)
-	msg = append(msg, publicSeed...)
-
-	sig, err := signer.Sign(msg)
+	sig, err := signer.Sign(ConfidentialDerivationMessage(publicSeed))
 	if err != nil {
-		return AeKey{}, fmt.Errorf("zkencryption: sign AeKey public seed: %w", err)
-	}
-	if sig == (solana.Signature{}) {
-		return AeKey{}, ErrDefaultSignature
+		return AeKey{}, fmt.Errorf("zkencryption: sign confidential-balances public seed: %w", err)
 	}
 	return AeKeyFromSignature(sig)
 }
 
 // AeKeyFromSeedPhraseAndPassphrase derives an AeKey from a BIP39 mnemonic and
 // an optional passphrase using the standard BIP39 PBKDF2-HMAC-SHA512 seed
-// derivation (2048 iterations, 64-byte output), matching
-// solana_seed_phrase::generate_seed_from_seed_phrase_and_passphrase. Solana
-// does not validate the mnemonic checksum at this layer, and neither do we.
+// derivation (2048 iterations, 64-byte output). The seed is used directly as
+// the HKDF input key material.
 func AeKeyFromSeedPhraseAndPassphrase(mnemonic, passphrase string) (AeKey, error) {
 	return AeKeyFromSeed(bip39.NewSeed(mnemonic, passphrase))
 }

--- a/programs/token-2022/zkencryption/confidential_keys.go
+++ b/programs/token-2022/zkencryption/confidential_keys.go
@@ -1,0 +1,42 @@
+package zkencryption
+
+import (
+	"fmt"
+
+	"github.com/gagliardetto/solana-go"
+)
+
+// DeriveConfidentialKeys derives both confidential-balances keys (AE and
+// ElGamal) from a single ed25519 signature over
+// ConfidentialDerivationMessage(publicSeed). The signer signs the message
+// exactly once and both keys are expanded from that one signature, so the two
+// keys always belong together and are reproducible even with non-deterministic
+// signers (hardware wallets, hedged ed25519). Mirrors derive_confidential_keys
+// in solana-zk-sdk.
+func DeriveConfidentialKeys(signer Signer, publicSeed []byte) (ElGamalSecretKey, AeKey, error) {
+	sig, err := signer.Sign(ConfidentialDerivationMessage(publicSeed))
+	if err != nil {
+		return ElGamalSecretKey{}, AeKey{}, fmt.Errorf("zkencryption: sign confidential-balances public seed: %w", err)
+	}
+	return DeriveConfidentialKeysFromSignature(sig)
+}
+
+// DeriveConfidentialKeysFromSignature derives both confidential-balances keys
+// (AE and ElGamal) from an ed25519 signature over
+// ConfidentialDerivationMessage. Mirrors derive_confidential_keys_from_signature
+// in solana-zk-sdk. An all-zero (default) signature is rejected, matching the
+// Rust implementation.
+func DeriveConfidentialKeysFromSignature(sig solana.Signature) (ElGamalSecretKey, AeKey, error) {
+	if sig == (solana.Signature{}) {
+		return ElGamalSecretKey{}, AeKey{}, ErrDefaultSignature
+	}
+	ae, err := deriveAeKey(sig[:])
+	if err != nil {
+		return ElGamalSecretKey{}, AeKey{}, err
+	}
+	el, err := deriveElGamalSecretKey(sig[:])
+	if err != nil {
+		return ElGamalSecretKey{}, AeKey{}, err
+	}
+	return el, ae, nil
+}

--- a/programs/token-2022/zkencryption/elgamal_secret.go
+++ b/programs/token-2022/zkencryption/elgamal_secret.go
@@ -1,7 +1,8 @@
 package zkencryption
 
 import (
-	"crypto/sha3"
+	"crypto/hkdf"
+	"crypto/sha512"
 	"fmt"
 
 	"filippo.io/edwards25519"
@@ -13,39 +14,62 @@ import (
 // encoded in little-endian form (matches curve25519-dalek Scalar::as_bytes).
 const ElGamalSecretKeyLen = 32
 
-// elGamalSigningDomain is the domain-separation prefix prepended to the
-// public seed before signing. It must match b"ElGamalSecretKey" in
-// solana-zk-sdk.
-const elGamalSigningDomain = "ElGamalSecretKey"
+// SigningDomain is the domain-separation prefix for confidential-balances key
+// derivation. It must match HKDF_SALT (b"solana-conf-bal/v1") in solana-zk-sdk
+// (derive_confidential_keys_from_ikm): it is both the message prefix the
+// signer signs and the HKDF salt.
+const SigningDomain = "solana-conf-bal/v1"
 
-// minElGamalSeedLen / maxElGamalSeedLen mirror the bounds enforced in
-// solana-zk-sdk's ElGamalSecretKey::from_seed implementation.
-const (
-	minElGamalSeedLen = ElGamalSecretKeyLen
-	maxElGamalSeedLen = 65535
-)
+// elgamalInfo is the HKDF info string that scopes the ElGamal expansion,
+// matching ELGAMAL_HKDF_INFO in solana-zk-sdk.
+const elgamalInfo = "elgamal"
+
+// elgamalMinSeedLen is the minimum seed length accepted by the ElGamal
+// derivation. It mirrors MINIMUM_SEED_LEN in solana-zk-sdk's
+// derive_confidential_keys_from_ikm (32), which is independent from the AE
+// minimum of 16.
+const elgamalMinSeedLen = ElGamalSecretKeyLen
+
+// maxSeedLen mirrors the maximum bound enforced by solana-zk-sdk's
+// derive_confidential_keys_from_ikm (MAXIMUM_IKM_LEN). It applies to both the
+// AE and ElGamal derivations.
+const maxSeedLen = 65535
 
 // ElGamalSecretKey is a canonical little-endian encoding of a Ristretto/Ed25519
 // scalar mod ell. It is the Token-2022 confidential-transfer ElGamal private
 // key; byte-for-byte equivalent to ElGamalSecretKey::as_bytes in solana-zk-sdk.
 type ElGamalSecretKey [ElGamalSecretKeyLen]byte
 
-// ElGamalSecretKeyFromSeed derives an ElGamal secret key from an entropy seed
-// by computing Scalar::from_bytes_mod_order_wide(SHA3-512(seed)), matching
-// curve25519-dalek's Scalar::hash_from_bytes::<Sha3_512>.
-func ElGamalSecretKeyFromSeed(seed []byte) (ElGamalSecretKey, error) {
-	if len(seed) < minElGamalSeedLen {
+// ConfidentialDerivationMessage returns the canonical confidential-balances
+// derivation message, b"solana-conf-bal/v1" || publicSeed. Mirrors
+// confidential_derivation_message in solana-zk-sdk; this is the exact message
+// a Signer must sign to derive confidential-balances keys.
+func ConfidentialDerivationMessage(publicSeed []byte) []byte {
+	msg := make([]byte, 0, len(SigningDomain)+len(publicSeed))
+	msg = append(msg, SigningDomain...)
+	msg = append(msg, publicSeed...)
+	return msg
+}
+
+// deriveElGamalSecretKey implements the solana-conf-bal/v1 derivation:
+// HKDF-SHA512(salt=SigningDomain, ikm).expand(info="elgamal", 64) reduced via
+// Scalar::from_bytes_mod_order_wide, matching derive_confidential_keys_from_ikm.
+func deriveElGamalSecretKey(ikm []byte) (ElGamalSecretKey, error) {
+	if len(ikm) < elgamalMinSeedLen {
 		return ElGamalSecretKey{}, ErrSeedTooShort
 	}
-	if len(seed) > maxElGamalSeedLen {
+	if len(ikm) > maxSeedLen {
 		return ElGamalSecretKey{}, ErrSeedTooLong
 	}
 
-	h := sha3.Sum512(seed)
-	// SetUniformBytes only errors on wrong input length; Sum512 always
-	// returns 64 bytes, so this branch is unreachable in practice but kept
-	// to avoid an implicit panic if the upstream contract ever changes.
-	s, err := edwards25519.NewScalar().SetUniformBytes(h[:])
+	wide, err := hkdf.Key(sha512.New, ikm, []byte(SigningDomain), elgamalInfo, 64)
+	if err != nil {
+		return ElGamalSecretKey{}, fmt.Errorf("zkencryption: HKDF expand elgamal: %w", err)
+	}
+	// SetUniformBytes performs Scalar::from_bytes_mod_order_wide on 64 bytes.
+	s, err := edwards25519.NewScalar().SetUniformBytes(wide)
+	// wide holds expanded secret material; scrub it before it leaves scope.
+	clear(wide)
 	if err != nil {
 		return ElGamalSecretKey{}, ErrInvalidScalarEncoding
 	}
@@ -55,38 +79,40 @@ func ElGamalSecretKeyFromSeed(seed []byte) (ElGamalSecretKey, error) {
 	return out, nil
 }
 
+// ElGamalSecretKeyFromSeed derives an ElGamal secret key from raw input key
+// material, matching derive_confidential_keys_from_ikm in solana-zk-sdk.
+func ElGamalSecretKeyFromSeed(seed []byte) (ElGamalSecretKey, error) {
+	return deriveElGamalSecretKey(seed)
+}
+
 // ElGamalSecretKeyFromSignature derives an ElGamal secret key from an ed25519
-// signature by using SHA3-512(signature) as the seed. Mirrors
-// ElGamalSecretKey::seed_from_signature + from_seed in solana-zk-sdk.
+// signature over ConfidentialDerivationMessage. Mirrors
+// derive_confidential_keys_from_signature in solana-zk-sdk. An all-zero
+// (default) signature is rejected, matching the Rust implementation.
 func ElGamalSecretKeyFromSignature(sig solana.Signature) (ElGamalSecretKey, error) {
-	h := sha3.Sum512(sig[:])
-	return ElGamalSecretKeyFromSeed(h[:])
+	if sig == (solana.Signature{}) {
+		return ElGamalSecretKey{}, ErrDefaultSignature
+	}
+	return deriveElGamalSecretKey(sig[:])
 }
 
 // ElGamalSecretKeyFromSigner deterministically derives an ElGamal secret key
 // from a Solana signer and a public seed. The signer signs
-// b"ElGamalSecretKey" || publicSeed; the signature is hashed with SHA3-512
-// and fed into ElGamalSecretKeyFromSeed. An all-zero (default) signature is
-// rejected to match the Rust implementation.
+// b"solana-conf-bal/v1" || publicSeed (see ConfidentialDerivationMessage); the
+// signature is fed through the HKDF-SHA512 solana-conf-bal/v1 derivation. The
+// all-zero signature rejection lives in ElGamalSecretKeyFromSignature.
 func ElGamalSecretKeyFromSigner(signer Signer, publicSeed []byte) (ElGamalSecretKey, error) {
-	msg := make([]byte, 0, len(elGamalSigningDomain)+len(publicSeed))
-	msg = append(msg, elGamalSigningDomain...)
-	msg = append(msg, publicSeed...)
-
-	sig, err := signer.Sign(msg)
+	sig, err := signer.Sign(ConfidentialDerivationMessage(publicSeed))
 	if err != nil {
-		return ElGamalSecretKey{}, fmt.Errorf("zkencryption: sign ElGamalSecretKey public seed: %w", err)
-	}
-	if sig == (solana.Signature{}) {
-		return ElGamalSecretKey{}, ErrDefaultSignature
+		return ElGamalSecretKey{}, fmt.Errorf("zkencryption: sign confidential-balances public seed: %w", err)
 	}
 	return ElGamalSecretKeyFromSignature(sig)
 }
 
 // ElGamalSecretKeyFromSeedPhraseAndPassphrase derives an ElGamal secret key
-// from a BIP39 mnemonic and an optional passphrase, matching
-// solana_seed_phrase's PBKDF2-HMAC-SHA512 derivation. Solana does not
-// validate the mnemonic checksum at this layer, and neither do we.
+// from a BIP39 mnemonic and an optional passphrase using the standard BIP39
+// PBKDF2-HMAC-SHA512 seed derivation (2048 iterations, 64-byte output). The
+// seed is used directly as the HKDF input key material.
 func ElGamalSecretKeyFromSeedPhraseAndPassphrase(mnemonic, passphrase string) (ElGamalSecretKey, error) {
 	return ElGamalSecretKeyFromSeed(bip39.NewSeed(mnemonic, passphrase))
 }

--- a/programs/token-2022/zkencryption/kdf_test.go
+++ b/programs/token-2022/zkencryption/kdf_test.go
@@ -265,3 +265,133 @@ func TestFromSigner_WrapsSignerError(t *testing.T) {
 		t.Fatalf("ElGamalSecretKeyFromSigner: err = %v, want wrapped sentinel", err)
 	}
 }
+
+func TestFromSignature_RejectsDefaultSignature(t *testing.T) {
+	t.Parallel()
+	var zero solana.Signature
+
+	if _, err := zkencryption.AeKeyFromSignature(zero); !errors.Is(err, zkencryption.ErrDefaultSignature) {
+		t.Fatalf("AeKeyFromSignature(zero): err = %v, want ErrDefaultSignature", err)
+	}
+	if _, err := zkencryption.ElGamalSecretKeyFromSignature(zero); !errors.Is(err, zkencryption.ErrDefaultSignature) {
+		t.Fatalf("ElGamalSecretKeyFromSignature(zero): err = %v, want ErrDefaultSignature", err)
+	}
+}
+
+func TestFromSigner_MatchesFromSignature(t *testing.T) {
+	t.Parallel()
+	seed32 := make([]byte, ed25519.SeedSize)
+	for i := range seed32 {
+		seed32[i] = byte(i)
+	}
+	priv := solana.PrivateKey(ed25519.NewKeyFromSeed(seed32))
+	publicSeed := []byte("some-mint-pubkey")
+
+	sig, err := priv.Sign(zkencryption.ConfidentialDerivationMessage(publicSeed))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	aeFromSigner, err := zkencryption.AeKeyFromSigner(priv, publicSeed)
+	if err != nil {
+		t.Fatalf("AeKeyFromSigner: %v", err)
+	}
+	aeFromSig, err := zkencryption.AeKeyFromSignature(sig)
+	if err != nil {
+		t.Fatalf("AeKeyFromSignature: %v", err)
+	}
+	if aeFromSigner != aeFromSig {
+		t.Errorf("AeKey signer/signature mismatch:\n signer: %x\n sig:    %x", aeFromSigner[:], aeFromSig[:])
+	}
+
+	elFromSigner, err := zkencryption.ElGamalSecretKeyFromSigner(priv, publicSeed)
+	if err != nil {
+		t.Fatalf("ElGamalSecretKeyFromSigner: %v", err)
+	}
+	elFromSig, err := zkencryption.ElGamalSecretKeyFromSignature(sig)
+	if err != nil {
+		t.Fatalf("ElGamalSecretKeyFromSignature: %v", err)
+	}
+	if elFromSigner != elFromSig {
+		t.Errorf("ElGamalSecretKey signer/signature mismatch:\n signer: %x\n sig:    %x", elFromSigner[:], elFromSig[:])
+	}
+}
+
+func TestDeriveConfidentialKeys_SingleSignature(t *testing.T) {
+	t.Parallel()
+	seed32 := make([]byte, ed25519.SeedSize)
+	for i := range seed32 {
+		seed32[i] = 0x2a
+	}
+	priv := solana.PrivateKey(ed25519.NewKeyFromSeed(seed32))
+	publicSeed := []byte("derive-confidential-keys-seed")
+
+	el, ae, err := zkencryption.DeriveConfidentialKeys(priv, publicSeed)
+	if err != nil {
+		t.Fatalf("DeriveConfidentialKeys: %v", err)
+	}
+
+	// The combined derivation must equal the individual derivations fed with
+	// the same signature.
+	sig, err := priv.Sign(zkencryption.ConfidentialDerivationMessage(publicSeed))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	aeSingle, err := zkencryption.AeKeyFromSignature(sig)
+	if err != nil {
+		t.Fatalf("AeKeyFromSignature: %v", err)
+	}
+	elSingle, err := zkencryption.ElGamalSecretKeyFromSignature(sig)
+	if err != nil {
+		t.Fatalf("ElGamalSecretKeyFromSignature: %v", err)
+	}
+	if ae != aeSingle {
+		t.Errorf("AE mismatch: combined %x, individual %x", ae[:], aeSingle[:])
+	}
+	if el != elSingle {
+		t.Errorf("ElGamalSecretKey mismatch: combined %x, individual %x", el[:], elSingle[:])
+	}
+
+	// The all-zero signature must be rejected in the combined path too.
+	if _, _, err := zkencryption.DeriveConfidentialKeysFromSignature(solana.Signature{}); !errors.Is(err, zkencryption.ErrDefaultSignature) {
+		t.Fatalf("DeriveConfidentialKeysFromSignature(zero): err = %v, want ErrDefaultSignature", err)
+	}
+}
+
+func TestLegacy_MatchesOldScheme(t *testing.T) {
+	t.Parallel()
+	// Expected values are the pre-solana-conf-bal/v1 SHA3-512 outputs that the
+	// old derivation produced for these inputs (retained from the original
+	// test vectors). They pin the legacy functions to the exact key material
+	// existing balances were derived with.
+	cases := []struct {
+		name, seedHex, aeHex, elgamalHex string
+	}{
+		{"all_zero_32", "0000000000000000000000000000000000000000000000000000000000000000",
+			"ad56c35cab5063b9e7ea568314ec81c4", "97e676b07bfa0d85006fc9c443428e90083a83a61116e65ccc2ba760ea66ab04"},
+		{"all_one_32", "1111111111111111111111111111111111111111111111111111111111111111",
+			"0c96e4cfe1285f5c2b9033c3ef50bbca", "23c6e7a2a3eeb66e823d6d8d113100f816b90467aabaf2244758c4e0a4882d06"},
+	}
+	for _, v := range cases {
+		t.Run(v.name, func(t *testing.T) {
+			t.Parallel()
+			seed := mustHex(t, v.seedHex)
+
+			ae, err := zkencryption.AeKeyFromSeedLegacy(seed)
+			if err != nil {
+				t.Fatalf("AeKeyFromSeedLegacy: %v", err)
+			}
+			if got := hex.EncodeToString(ae[:]); got != v.aeHex {
+				t.Errorf("AeKey mismatch: got %s want %s", got, v.aeHex)
+			}
+
+			el, err := zkencryption.ElGamalSecretKeyFromSeedLegacy(seed)
+			if err != nil {
+				t.Fatalf("ElGamalSecretKeyFromSeedLegacy: %v", err)
+			}
+			if got := hex.EncodeToString(el[:]); got != v.elgamalHex {
+				t.Errorf("ElGamalSecretKey mismatch: got %s want %s", got, v.elgamalHex)
+			}
+		})
+	}
+}

--- a/programs/token-2022/zkencryption/legacy.go
+++ b/programs/token-2022/zkencryption/legacy.go
@@ -1,0 +1,125 @@
+package zkencryption
+
+import (
+	"crypto/sha3"
+	"fmt"
+
+	"filippo.io/edwards25519"
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/bip39"
+)
+
+// The functions in this file preserve the pre-solana-conf-bal/v1 SHA3-512 key
+// derivation. Callers who created keys under the old scheme can use them to
+// reproduce the same key material and decrypt balances encrypted before the
+// migration. New code must use the solana-conf-bal/v1 functions in ae_key.go
+// and elgamal_secret.go; these variants are retained for migration only.
+
+// aeLegacySigningDomain is the domain-separation prefix used by the legacy AE
+// derivation. It must match b"AeKey" in solana-zk-sdk.
+const aeLegacySigningDomain = "AeKey"
+
+// aeLegacyMinSeedLen mirrors the minimum accepted by the legacy SeedDerivable
+// implementation for AeKey in solana-zk-sdk.
+const aeLegacyMinSeedLen = AeKeyLen
+
+// elgamalLegacySigningDomain is the domain-separation prefix used by the legacy
+// ElGamal derivation. It must match b"ElGamalSecretKey" in solana-zk-sdk.
+const elgamalLegacySigningDomain = "ElGamalSecretKey"
+
+// elgamalLegacyMinSeedLen mirrors the minimum accepted by the legacy
+// ElGamalSecretKey::from_seed implementation in solana-zk-sdk.
+const elgamalLegacyMinSeedLen = ElGamalSecretKeyLen
+
+// Deprecated: legacy SHA3-512 AE derivation. Prefer AeKeyFromSeed
+// (solana-conf-bal/v1). Use only to reproduce keys derived under the pre-v1
+// scheme.
+func AeKeyFromSeedLegacy(seed []byte) (AeKey, error) {
+	if len(seed) < aeLegacyMinSeedLen {
+		return AeKey{}, ErrSeedTooShort
+	}
+	if len(seed) > maxSeedLen {
+		return AeKey{}, ErrSeedTooLong
+	}
+	h := sha3.Sum512(seed)
+	var out AeKey
+	copy(out[:], h[:AeKeyLen])
+	return out, nil
+}
+
+// Deprecated: legacy SHA3-512 AE derivation from a signature. Prefer
+// AeKeyFromSignature (solana-conf-bal/v1).
+func AeKeyFromSignatureLegacy(sig solana.Signature) (AeKey, error) {
+	h := sha3.Sum512(sig[:])
+	return AeKeyFromSeedLegacy(h[:])
+}
+
+// Deprecated: legacy SHA3-512 AE derivation from a signer. Prefer
+// AeKeyFromSigner (solana-conf-bal/v1).
+func AeKeyFromSignerLegacy(signer Signer, publicSeed []byte) (AeKey, error) {
+	msg := make([]byte, 0, len(aeLegacySigningDomain)+len(publicSeed))
+	msg = append(msg, aeLegacySigningDomain...)
+	msg = append(msg, publicSeed...)
+	sig, err := signer.Sign(msg)
+	if err != nil {
+		return AeKey{}, fmt.Errorf("zkencryption: sign legacy AeKey public seed: %w", err)
+	}
+	if sig == (solana.Signature{}) {
+		return AeKey{}, ErrDefaultSignature
+	}
+	return AeKeyFromSignatureLegacy(sig)
+}
+
+// Deprecated: legacy SHA3-512 AE derivation from a BIP39 mnemonic. Prefer
+// AeKeyFromSeedPhraseAndPassphrase (solana-conf-bal/v1).
+func AeKeyFromSeedPhraseAndPassphraseLegacy(mnemonic, passphrase string) (AeKey, error) {
+	return AeKeyFromSeedLegacy(bip39.NewSeed(mnemonic, passphrase))
+}
+
+// Deprecated: legacy SHA3-512 ElGamal derivation. Prefer
+// ElGamalSecretKeyFromSeed (solana-conf-bal/v1).
+func ElGamalSecretKeyFromSeedLegacy(seed []byte) (ElGamalSecretKey, error) {
+	if len(seed) < elgamalLegacyMinSeedLen {
+		return ElGamalSecretKey{}, ErrSeedTooShort
+	}
+	if len(seed) > maxSeedLen {
+		return ElGamalSecretKey{}, ErrSeedTooLong
+	}
+	h := sha3.Sum512(seed)
+	s, err := edwards25519.NewScalar().SetUniformBytes(h[:])
+	if err != nil {
+		return ElGamalSecretKey{}, ErrInvalidScalarEncoding
+	}
+	var out ElGamalSecretKey
+	copy(out[:], s.Bytes())
+	return out, nil
+}
+
+// Deprecated: legacy SHA3-512 ElGamal derivation from a signature. Prefer
+// ElGamalSecretKeyFromSignature (solana-conf-bal/v1).
+func ElGamalSecretKeyFromSignatureLegacy(sig solana.Signature) (ElGamalSecretKey, error) {
+	h := sha3.Sum512(sig[:])
+	return ElGamalSecretKeyFromSeedLegacy(h[:])
+}
+
+// Deprecated: legacy SHA3-512 ElGamal derivation from a signer. Prefer
+// ElGamalSecretKeyFromSigner (solana-conf-bal/v1).
+func ElGamalSecretKeyFromSignerLegacy(signer Signer, publicSeed []byte) (ElGamalSecretKey, error) {
+	msg := make([]byte, 0, len(elgamalLegacySigningDomain)+len(publicSeed))
+	msg = append(msg, elgamalLegacySigningDomain...)
+	msg = append(msg, publicSeed...)
+	sig, err := signer.Sign(msg)
+	if err != nil {
+		return ElGamalSecretKey{}, fmt.Errorf("zkencryption: sign legacy ElGamalSecretKey public seed: %w", err)
+	}
+	if sig == (solana.Signature{}) {
+		return ElGamalSecretKey{}, ErrDefaultSignature
+	}
+	return ElGamalSecretKeyFromSignatureLegacy(sig)
+}
+
+// Deprecated: legacy SHA3-512 ElGamal derivation from a BIP39 mnemonic. Prefer
+// ElGamalSecretKeyFromSeedPhraseAndPassphrase (solana-conf-bal/v1).
+func ElGamalSecretKeyFromSeedPhraseAndPassphraseLegacy(mnemonic, passphrase string) (ElGamalSecretKey, error) {
+	return ElGamalSecretKeyFromSeedLegacy(bip39.NewSeed(mnemonic, passphrase))
+}

--- a/programs/token-2022/zkencryption/testdata/kdf_vectors.json
+++ b/programs/token-2022/zkencryption/testdata/kdf_vectors.json
@@ -3,40 +3,46 @@
     {
       "name": "all_zero_32",
       "seed_hex": "0000000000000000000000000000000000000000000000000000000000000000",
-      "ae_key_hex": "ad56c35cab5063b9e7ea568314ec81c4",
-      "elgamal_secret_hex": "97e676b07bfa0d85006fc9c443428e90083a83a61116e65ccc2ba760ea66ab04"
+      "ae_key_hex": "031493ec015bbe3450729a9fe7054b38",
+      "elgamal_secret_hex": "faea9f54648fa9e6fb277a56b1327ea97c5155f7ec15803a3e84e8ff64bd0f02"
     },
     {
       "name": "all_one_32",
       "seed_hex": "1111111111111111111111111111111111111111111111111111111111111111",
-      "ae_key_hex": "0c96e4cfe1285f5c2b9033c3ef50bbca",
-      "elgamal_secret_hex": "23c6e7a2a3eeb66e823d6d8d113100f816b90467aabaf2244758c4e0a4882d06"
+      "ae_key_hex": "9f9bf1b5671efa05828409d27fce5f5e",
+      "elgamal_secret_hex": "0d82a79c7eb2bc908b634ea769a6347c4bd49fef31ee7add933df779c0813e00"
     },
     {
       "name": "ascending_64",
       "seed_hex": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
-      "ae_key_hex": "cb29601efbee71f4dfbb7f1c2bdaeafd",
-      "elgamal_secret_hex": "ac5aeea5fc28ef2541a9ee1805f7f3e530c290139f82cbd426b50cc9ce4c670e"
+      "ae_key_hex": "e017b6ce58298a3920fb64283f008827",
+      "elgamal_secret_hex": "5f69ceca60fd31d0d08d9ccb9f633e205edc47cb6f48ec23a8d535bfe902a30a"
     },
     {
       "name": "mixed_48",
       "seed_hex": "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f30",
-      "ae_key_hex": "5e2771d81531881122aaf5b0e03541cc",
-      "elgamal_secret_hex": "65aa89be80a1a2bd7a57c7f826fa55db8000f33f4b071575bfa915e6b1484a0f"
+      "ae_key_hex": "02add2c811f5a3cebf3bfdbe0d75856c",
+      "elgamal_secret_hex": "5967d1e8da88a8ded80ea4fe945937bbe1f8744c81554dabdaee9ace883ced0f"
+    },
+    {
+      "name": "canonical_ikm_0x42",
+      "seed_hex": "42424242424242424242424242424242424242424242424242424242424242424242424242424242424242424242424242424242424242424242424242424242",
+      "ae_key_hex": "1b29778a3493dab218c24e87144be43d",
+      "elgamal_secret_hex": "716d2431fa74fc1c48ffb9b9972b0be2f0b29ab755081f2ea35d3c74f442190e"
     }
   ],
   "from_signature": [
     {
       "name": "sig_deadbeef",
       "signature_hex": "dee5ecf3fa01080f161d242b323940474e555c636a71787f868d949ba2a9b0b7bec5ccd3dae1e8eff6fd040b121920272e353c434a51585f666d747b82899097",
-      "ae_key_hex": "83d76b6e585202327352f43cb937f222",
-      "elgamal_secret_hex": "d971ca8cfb4fe603c38d0994284eafc783f7a79fd834246f012cc27715333405"
+      "ae_key_hex": "5dc8b1d6537d4847d785c9efa0241a96",
+      "elgamal_secret_hex": "4357c8f0644299410cffd9fcb66fb377597dc7a8e52303a7ea7a4781fb4ae907"
     },
     {
       "name": "sig_increment",
       "signature_hex": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
-      "ae_key_hex": "10de808f82059adfa2992d0cdaa845df",
-      "elgamal_secret_hex": "d4a09f7c774de4c629e8cce1c8943709c95026a54c079ed63ee98cd15307610f"
+      "ae_key_hex": "e017b6ce58298a3920fb64283f008827",
+      "elgamal_secret_hex": "5f69ceca60fd31d0d08d9ccb9f633e205edc47cb6f48ec23a8d535bfe902a30a"
     }
   ],
   "from_signer": [
@@ -44,29 +50,29 @@
       "name": "keypair_a_empty_seed",
       "keypair_secret_hex": "112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00",
       "public_seed_hex": "",
-      "ae_key_hex": "c22f9bd211f5f0758517a316d99c7842",
-      "elgamal_secret_hex": "1c39bd311012f04bff07474a87fe32dd240e9dc53c5f0e50c81cda1b972f9d08"
+      "ae_key_hex": "6417eedbcbe9c64a72395719ec98cf6b",
+      "elgamal_secret_hex": "be5cce951f42a2a8677d1a56f03aae7bff795b38cf1c56c8cf3a4dae7d60e205"
     },
     {
       "name": "keypair_a_mint_seed",
       "keypair_secret_hex": "112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00",
       "public_seed_hex": "736f6d652d6d696e742d7075626b6579",
-      "ae_key_hex": "4d844c1ca59daf8547106b218e612b26",
-      "elgamal_secret_hex": "2b1de3492590211b779acba99048339c845e5c7cf5c95f2bf1d4352ff105d50c"
+      "ae_key_hex": "8140c9e45b29666e543f3bb209f81e0c",
+      "elgamal_secret_hex": "bac74bc7b5aae7cf20e9f30bc1c73f77c5b29619f3382671dc11892abd38d903"
     },
     {
       "name": "keypair_b_mint_seed",
       "keypair_secret_hex": "7e577e57aabbccddeeff00112233445566778899aabbccddeeff001122334455",
       "public_seed_hex": "736f6d652d6d696e742d7075626b6579",
-      "ae_key_hex": "15715bd1aa276dd1653c9dd28e780971",
-      "elgamal_secret_hex": "8d3a6cb60be0b4a01c1cfab479487c2a701c3e71d28ad9cf422f9262d06aef04"
+      "ae_key_hex": "928192a47fd22b836afa37c865ff2a3a",
+      "elgamal_secret_hex": "56e91ccaa29ee7bc8ffe56a1473bfcb6216056b6dc1ceb0460ea4e21495fe70f"
     },
     {
       "name": "keypair_b_long_seed",
       "keypair_secret_hex": "7e577e57aabbccddeeff00112233445566778899aabbccddeeff001122334455",
       "public_seed_hex": "612d7261746865722d6c6f6e6765722d7075626c69632d736565642d757365642d666f722d646f6d61696e2d73657061726174696f6e",
-      "ae_key_hex": "2da6c7bc25bd3b82b19b2cfba74d6e0d",
-      "elgamal_secret_hex": "a529aef3895d534e2140e06a6b558bbb20b6a124d548c01385de9f3a90272300"
+      "ae_key_hex": "bfc880c25080e219135c00707365b847",
+      "elgamal_secret_hex": "e898671ba0104ee47fc21e7affcc7307cff0a5ce46f6f38af40c7b859ac32006"
     }
   ],
   "from_mnemonic": [
@@ -74,22 +80,22 @@
       "name": "trezor_all_abandon_no_passphrase",
       "mnemonic": "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
       "passphrase": "",
-      "ae_key_hex": "23f20b9df0405b4675fd27d682bb2a30",
-      "elgamal_secret_hex": "55def0e683cd64d0918c93672835def6253d8ba5bee85df27c4daa34abeb5e03"
+      "ae_key_hex": "2322f6c8bdb611d6e719af59da2760c0",
+      "elgamal_secret_hex": "2473fe655d4a4c8cd769aab512ab70f8565621db4ed0d64acc5f98620b051404"
     },
     {
       "name": "trezor_all_abandon_trezor_passphrase",
       "mnemonic": "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
       "passphrase": "TREZOR",
-      "ae_key_hex": "c7cca7af94c37e320752a00aef3425cb",
-      "elgamal_secret_hex": "3297e41ec815c1d17368a20c925d0f4d786967fa8e96f1179b2dcd646ffa6905"
+      "ae_key_hex": "de34d84b31764422dcacf551deef5835",
+      "elgamal_secret_hex": "bb90d68643d3a1018b649d59278a5136d7a34759a7602ee373f32f226c123803"
     },
     {
       "name": "legal_winner_trezor",
       "mnemonic": "legal winner thank year wave sausage worth useful legal winner thank yellow",
       "passphrase": "TREZOR",
-      "ae_key_hex": "da372f904b8542269d20d80fec8c4188",
-      "elgamal_secret_hex": "f2fb947e011587f12047631c94e80777177486437c12b1db93d146f4a2823b0b"
+      "ae_key_hex": "f6fce08af0b5d5cd0d4d24527418bfd2",
+      "elgamal_secret_hex": "8ed05cefe094a608252e3e7252c7585739fdbc292e7796e7f7e66027a0d44a07"
     }
   ]
 }


### PR DESCRIPTION
## What

The `zkencryption` package derives Token-2022 confidential-transfer keys with
the pre-v1 scheme: it signs `b"AeKey"` / `b"ElGamalSecretKey"` as the signing
domain and hashes the signature with SHA3-512(SHA3-512(...)).

The current standard (`solana-conf-bal/v1`, see
`derive_confidential_keys_from_ikm` in solana-zk-sdk and the reference JS
`@solana/zk-sdk` `ConfidentialKeys.signerMessage`) signs
`b"solana-conf-bal/v1" || public_seed` and derives keys with HKDF-SHA512
(salt `b"solana-conf-bal/v1"`, info `b"ae"` for the 16-byte AE key and
`b"elgamal"` for the 64-byte input reduced via
`Scalar::from_bytes_mod_order_wide`).

As a result the Go SDK derives different keys than the Rust and JS/WASM
reference clients for the same signer and public seed. An account configured
with a Go-derived ElGamal pubkey cannot be recovered or decrypted from any
standard client, and a Go SDK cannot read accounts configured elsewhere.

## What changed

- `ae_key.go` / `elgamal_secret.go`: derive via HKDF-SHA512 with the
  `solana-conf-bal/v1` salt and signing domain, matching current zk-sdk.
- `kdf_vectors.json`: regenerated against the canonical derivation. Every
  vector was cross-checked against an independent implementation of
  HKDF-SHA512 and RFC 8032 ed25519 (pure Python), not just against the
  package itself.
- The minimum seed length for the AE key moves from 16 to 32 bytes to match
  `MINIMUM_IKM_LEN` in solana-zk-sdk.

Note: this is a behavioral breaking change for anyone relying on the legacy
derivation. Those keys were never interoperable with the standard clients, so
there is no working cross-client state to preserve.

## Testing

`go test ./programs/token-2022/zkencryption/ -count=1` passes. All 13 test
vectors (from_seed, from_signature, from_signer, from_mnemonic) agree with
the independent Python reference.
