### PR TITLE
fix(rpc): decode VoteAccounts EpochCredits as uint64

### DIFF
--- a/rpc/getVoteAccounts.go
+++ b/rpc/getVoteAccounts.go
@@ -96,5 +96,5 @@ type VoteAccountsResult struct {
 
 	// History of how many credits earned by the end of each epoch,
 	// as an array of arrays containing: [epoch, credits, previousCredits]
-	EpochCredits [][]int64 `json:"epochCredits,omitempty"`
+	EpochCredits [][]uint64 `json:"epochCredits,omitempty"`
 }


### PR DESCRIPTION
Alpenglow clusters return `u64::MAX` (18446744073709551615) sentinel values in `epochCredits` for some delinquent vote accounts. These overflow `int64` during JSON decoding, which fails the entire `GetVoteAccounts` call — one bad validator in the response makes the RPC method unusable against Alpenglow clusters.

Solana defines vote credits as `u64`, so this widens `VoteAccountsResult.EpochCredits` from `[][]int64` to `[][]uint64` to represent the full range.

Note this is a breaking change for callers doing signed arithmetic on credits. Happy to adjust the approach (separate field, or targeting a major release) if you'd prefer.

Downstream PRs waiting on this fix landing in a release:
- SOL-Strategies/solana-validator-ha#62
- SOL-Strategies/solana-validator-failover#90