### PR TITLE
chore: change test count from 100 to 1 in workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Test
-        run: go test ./... -race -count=100
+        run: go test ./... -race -count=1


### PR DESCRIPTION
Every test ran 100 times under -race on every PR, which pushed the macos-latest job past Go's default 10-minute per-package timeout and produced recurring false failures (#475, #481). -count=1 keeps the cache disabled, which is what was intended.