### PR TITLE
fix(keys): FindProgramAddress must not mutate/alias caller's seed slice

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -711,7 +711,16 @@ func FindProgramAddress(seed [][]byte, programID PublicKey) (PublicKey, uint8, e
 	var err error
 	bumpSeed := uint8(math.MaxUint8)
 	for bumpSeed != 0 {
-		address, err = CreateProgramAddress(append(seed, []byte{byte(bumpSeed)}), programID)
+		// Build a fresh seed set each iteration instead of append(seed, ...):
+		// appending onto the caller's slice can write into its backing array
+		// (when it has spare capacity), corrupting the caller's data and causing
+		// a data race when FindProgramAddress is called concurrently on shared
+		// seeds.
+		seeds := make([][]byte, len(seed), len(seed)+1)
+		copy(seeds, seed)
+		seeds = append(seeds, []byte{byte(bumpSeed)})
+
+		address, err = CreateProgramAddress(seeds, programID)
 		if err == nil {
 			return address, bumpSeed, nil
 		}

--- a/keys_test.go
+++ b/keys_test.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"flag"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -719,4 +720,45 @@ func TestFindTokenMetadataAddress(t *testing.T) {
 	// https://solscan.io/account/GfihrEYCPrvUyrMyMQPdhGEStxa9nKEK2Wfn9iK4AZq2
 	assert.Equal(t, metadataPDA, MustPublicKeyFromBase58("GfihrEYCPrvUyrMyMQPdhGEStxa9nKEK2Wfn9iK4AZq2"))
 	assert.Equal(t, bumpSeed, uint8(0xfd))
+}
+
+func TestFindProgramAddress_DoesNotMutateCallerSeeds(t *testing.T) {
+	// FindProgramAddress must not write into the caller's seed slice backing
+	// array. Give the slice spare capacity so a naive append(seed, bump) would
+	// reuse (and corrupt) the caller's backing array.
+	seeds := make([][]byte, 2, 4)
+	seeds[0] = []byte("Lil'")
+	seeds[1] = []byte("Bits")
+	programID := NewWallet().PrivateKey.PublicKey()
+
+	_, _, err := FindProgramAddress(seeds, programID)
+	require.NoError(t, err)
+
+	// Length unchanged, contents intact.
+	require.Equal(t, 2, len(seeds))
+	require.Equal(t, []byte("Lil'"), seeds[0])
+	require.Equal(t, []byte("Bits"), seeds[1])
+
+	// The caller can safely append their own next seed without reading a value
+	// smuggled in by FindProgramAddress.
+	mine := append(seeds, []byte("mine"))
+	require.Equal(t, []byte("mine"), mine[2])
+}
+
+func TestFindProgramAddress_ConcurrentSharedSeedsNoRace(t *testing.T) {
+	// Run with -race: concurrent derivation from a shared seed set must not
+	// race on the caller's backing array.
+	seeds := make([][]byte, 1, 2)
+	seeds[0] = []byte("authority")
+	programID := NewWallet().PrivateKey.PublicKey()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _, _ = FindProgramAddress(seeds, programID)
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
## Problem

`FindProgramAddress` derives the bump by calling:

```go
address, err = CreateProgramAddress(append(seed, []byte{byte(bumpSeed)}), programID)
```

`append(seed, ...)` reuses the **caller's** slice backing array whenever it has spare capacity. So `FindProgramAddress` writes the bump byte into memory the caller still owns. Two consequences:

1. **Caller data corruption** — a caller that passes a seed slice with spare capacity (e.g. `make([][]byte, n, n+1)`) and later appends its own next element reads back a value smuggled in by `FindProgramAddress`.
2. **Data race** — calling `FindProgramAddress` concurrently with a shared seed slice races on that backing array.

The race is real and reproducible with `go test -race`:

```
WARNING: DATA RACE
Write at 0x... by goroutine 9:
  github.com/gagliardetto/solana-go.FindProgramAddress()
Previous write at 0x... by goroutine 15:
  github.com/gagliardetto/solana-go.FindProgramAddress()
```

## Fix

Build a fresh seed set each iteration instead of appending onto the caller's slice:

```go
seeds := make([][]byte, len(seed), len(seed)+1)
copy(seeds, seed)
seeds = append(seeds, []byte{byte(bumpSeed)})
address, err = CreateProgramAddress(seeds, programID)
```

Derivation results are unchanged; only the aliasing is removed.

## Tests

Added to `keys_test.go`:
- `TestFindProgramAddress_DoesNotMutateCallerSeeds` — passes a spare-capacity seed slice, asserts its length/contents are intact after the call and that a subsequent caller append is not corrupted.
- `TestFindProgramAddress_ConcurrentSharedSeedsNoRace` — concurrent derivation from a shared seed set (fails under `-race` before the fix, clean after).

The existing `TestFindProgramAddress` (1000-iteration parity vs `CreateProgramAddress`) still passes, confirming results are unchanged.

## Verification

Built and tested locally with Go 1.23:

```
go test ./ -race     # ok — full package, including the new concurrent test
go vet ./            # clean
```

Confirmed the race detector fires before the change and is silent after.
