### PR TITLE
feat(rpc): add costUnits to transaction meta

### DIFF
--- a/rpc/types.go
+++ b/rpc/types.go
@@ -267,6 +267,10 @@ type TransactionMeta struct {
 	ReturnData ReturnData `json:"returnData"`
 
 	ComputeUnitsConsumed *uint64 `json:"computeUnitsConsumed"`
+
+	// The cost the block cost model charged this transaction against the block
+	// limits. Nil when the RPC node does not report it.
+	CostUnits *uint64 `json:"costUnits"`
 }
 
 type ReturnData struct {
@@ -569,6 +573,10 @@ type ParsedTransactionMeta struct {
 	ReturnData ReturnData `json:"returnData"`
 
 	ComputeUnitsConsumed *uint64 `json:"computeUnitsConsumed"`
+
+	// The cost the block cost model charged this transaction against the block
+	// limits. Nil when the RPC node does not report it.
+	CostUnits *uint64 `json:"costUnits"`
 }
 
 type ParsedInnerInstruction struct {


### PR DESCRIPTION
The RPC reports the block cost model charge alongside the compute units consumed, on both the binary and the jsonParsed transaction meta.